### PR TITLE
Empty return for addLoadBalancer

### DIFF
--- a/src/main/proto/netflix/titus/titus_loadbalancer_api.proto
+++ b/src/main/proto/netflix/titus/titus_loadbalancer_api.proto
@@ -49,7 +49,7 @@ service LoadBalancerService {
     }
 
     /// Add a load balancer to a Job.
-    rpc AddLoadBalancer (AddLoadBalancerRequest) returns (LoadBalancerId) {
+    rpc AddLoadBalancer (AddLoadBalancerRequest) returns (google.protobuf.Empty) {
     }
 
     /// Remove a load balancer from a Job.


### PR DESCRIPTION
Remove the needless return value from addLoadBalancer before anyone starts using the API.