### PR TITLE
This makes it so the project can be govendored

### DIFF
--- a/src/main/proto/netflix/titus/api.go
+++ b/src/main/proto/netflix/titus/api.go
@@ -1,0 +1,3 @@
+package titus
+
+// This exists for no other reason than to please Go package managers


### PR DESCRIPTION
We add a go file so that Go vendoring tools think this is a
go package.