### PR TITLE
allow entrypoint and command to be passed down to agents as lists

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+### Description of the Change
+
+**FIXME**: please add at least one sentence explaining why changes here are being made.

--- a/src/main/proto/netflix/titus/agent.proto
+++ b/src/main/proto/netflix/titus/agent.proto
@@ -262,9 +262,9 @@ message ContainerInfo {
     //
     // Both CMD and ENTRYPOINT baked into the image can be explicitly cleared with a single empty value (i.e.: `[""]`).
     message Process {
-        // when set will override ENTRYPOINT baked into the image, and cause CMD from the image to be ignored
+        // when set, will override ENTRYPOINT baked into the image, and cause CMD from the image to be ignored
         repeated string entrypoint = 1;
-        // when set will override CMD baked into the image
+        // when set, will override CMD baked into the image
         repeated string command = 2;
     }
     // Process to be executed inside the container

--- a/src/main/proto/netflix/titus/agent.proto
+++ b/src/main/proto/netflix/titus/agent.proto
@@ -86,9 +86,11 @@ message ContainerInfo {
 
     optional SnapshotPolicy snapshotPolicy = 10 [deprecated = true];
 
-    repeated string entrypointCmd = 11; // Deprecated. Use entrypointStr instead.
+    // deprecated: Use process instead
+    repeated string entrypointCmd = 11 [deprecated = true];
 
-    optional string entrypointStr = 13;
+    // deprecated: Use process instead
+    optional string entrypointStr = 13 [deprecated = true];
 
     optional string appName = 14;
 
@@ -254,4 +256,17 @@ message ContainerInfo {
 
     // passthrough attributes are an arbitrary set of key / value pairs that are passed from API to executor
     map<string, string> passthroughAttributes = 37;
+
+    // entrypoint and command follow Docker semantics, and can be used to override what is baked into the Docker image:
+    // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+    //
+    // Both CMD and ENTRYPOINT baked into the image can be explicitly cleared with a single empty value (i.e.: `[""]`).
+    message Process {
+        // when set will override ENTRYPOINT baked into the image, and cause CMD from the image to be ignored
+        repeated string entrypoint = 1;
+        // when set will override CMD baked into the image
+        repeated string command = 2;
+    }
+    // Process to be executed inside the container
+    optional Process process = 38;
 }

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -133,10 +133,16 @@ message Container {
     /// (Optional) Arbitrary set of key/value pairs. Key names starting with 'titus.' are reserved by Titus.
     map<string, string> attributes = 4;
 
-    /// (Optional) A binary to execute with parameters. If not set, the entry point must be defined in the container image.
+    /// (Optional) Override the entry point of the image.
+    // If set, the command baked into the image (if any) is always ignored. Interactions between the entry point and
+    // command are the same as specified by Docker:
+    // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+    //
+    //  To simply clear (unset) the entry point of the image, pass a single empty string value: [""]
     repeated string entryPoint = 5;
 
-    /// (Optional, not supported yet) Additional parameters for the entry point defined either here or provided in the container image
+    /// (Optional) Additional parameters for the entry point defined either here or provided in the container image.
+    // To simply clear (unset) the command of the image, pass a single empty string value: [""]
     repeated string command = 6;
 
     /// (Optional) A collection of system environment variables passed to the container.

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -138,11 +138,11 @@ message Container {
     // command are the same as specified by Docker:
     // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
     //
-    //  To simply clear (unset) the entry point of the image, pass a single empty string value: [""]
+    //  To clear (unset) the entry point of the image, pass a single empty string value: [""]
     repeated string entryPoint = 5;
 
     /// (Optional) Additional parameters for the entry point defined either here or provided in the container image.
-    // To simply clear (unset) the command of the image, pass a single empty string value: [""]
+    // To clear (unset) the command of the image, pass a single empty string value: [""]
     repeated string command = 6;
 
     /// (Optional) A collection of system environment variables passed to the container.


### PR DESCRIPTION
Align how agents receive entrypoint and command to the V3 API, where they are lists of arguments. This makes shell parsing more explicit and a responsibility of callers of the API.

This will also allow the executor to start supporting custom `CMDs`.

Note about backwards compatibility: I left the flat string entrypoint field as deprecated, with the idea that initially the control plane will only set the new `Process` field for Jobs that specify a custom `command`. This will prevent breaking existing jobs while adding the new capability.