### PR TITLE
Add InstanceStateUnknown in the InstanceLifecycleState enum

### DIFF
--- a/src/main/proto/netflix/titus/titus_agent_api.proto
+++ b/src/main/proto/netflix/titus/titus_agent_api.proto
@@ -32,6 +32,9 @@ enum InstanceLifecycleState {
 
     /// An agent instance is not running anymore.
     Stopped = 3;
+
+    /// An agent instance state is unknown.
+    InstanceStateUnknown = 4;
 }
 
 /// Agent instance deployment status.


### PR DESCRIPTION
### Description of the Change

The unknown state is present in the TitusMaster core model, so we need
it here for the proper mapping.
