### PR TITLE
add the removable agent override state

### DIFF
--- a/src/main/proto/netflix/titus/titus_agent_api.proto
+++ b/src/main/proto/netflix/titus/titus_agent_api.proto
@@ -54,6 +54,9 @@ enum InstanceOverrideState {
     /// An agent instance is in the quarantined mode and is not accepting any traffic, unless a job directly requests
     //  to be placed there.
     Quarantined = 1;
+
+    /// An agent instance is in the removable state and will be removed once it becomes idles.
+    Removable = 2;
 }
 
 /// Agent instance override status.


### PR DESCRIPTION
### Description of the Change

Add agent instance `Removable` state to mark agents that need to be removed once they become idle.