### PR TITLE
Rename agent state to AgentRemovable

### DIFF
--- a/src/main/proto/netflix/titus/titus_agent_api.proto
+++ b/src/main/proto/netflix/titus/titus_agent_api.proto
@@ -56,7 +56,7 @@ enum InstanceOverrideState {
     Quarantined = 1;
 
     /// An agent instance is in the removable state and will be removed once it becomes idles.
-    Removable = 2;
+    AgentRemovable = 2;
 }
 
 /// Agent instance override status.


### PR DESCRIPTION

### Description of the Change

Rename agent state to `AgentRemovable` due to conflict with instance group state.