### PR TITLE
Eviction service/disruption budget updates

### DIFF
--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -137,7 +137,7 @@ enum Tier {
 
 /// Titus hierarchy level.
 enum Level {
-    GlobalLevel = 0;
+    SystemLevel = 0;
     TierLevel = 1;
     CapacityGroupLevel = 2;
     JobLevel = 3;
@@ -146,12 +146,12 @@ enum Level {
 
 /// A reference to an entity in the Titus hierarchy.
 message Reference {
-    message Global {
+    message System {
     }
 
     oneof Reference {
-        /// Global level.
-        Global global = 1;
+        /// System level.
+        System system = 1;
 
         /// Tier level
         Tier tier = 2;
@@ -218,8 +218,11 @@ message TimeWindow {
     /// (Required) Included days.
     repeated Day days = 1;
 
-    /// (Optional) Included hour ranges.
+    /// (Optional) Included hour ranges. If not set, defaults to 0-24.
     repeated HourlyTimeWindow hourlyTimeWindows = 2;
+
+    /// (Optional) If not set, UTC time zone is set as a default.
+    string timeZone = 3;
 }
 
 /// A provider for container health

--- a/src/main/proto/netflix/titus/titus_eviction_api.proto
+++ b/src/main/proto/netflix/titus/titus_eviction_api.proto
@@ -20,7 +20,7 @@ option go_package = "titus";
 // ----------------------------------------------------------------------------
 // Eviction core data structures
 
-/// Current eviction quota at the global, tier, capacity group, and job level. The total amount of tasks that
+/// Current eviction quota at the system, tier, capacity group, and job level. The total amount of tasks that
 //  can be evicted at a given point in time is constraint by this number.
 message EvictionQuota {
     /// System layer/entity refrence.


### PR DESCRIPTION
### Description of the Change

Rename the top level reference from `Global` to `System`. Add timezone to `TimeWindow` message.