### PR TITLE
add an experimental API for moving tasks across two distinct jobs

### DIFF
--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -703,6 +703,14 @@ message TaskKillRequest {
     bool shrink = 2;
 }
 
+message TaskMoveRequest {
+    /// (Required) Task to move.
+    string taskId = 1;
+
+    /// (Required) Job which is the recipient of the task.
+    string targetJobId = 2;
+}
+
 service JobManagementService {
 
     // ------------------------------------------------------------
@@ -763,5 +771,9 @@ service JobManagementService {
 
     /// Terminate a task with the given id. Depending on job type, the task might be immediately restarted/replaced with a new one.
     rpc KillTask (TaskKillRequest) returns (google.protobuf.Empty) {
+    }
+
+    /// Move a task from one job to another.
+    rpc MoveTask (TaskMoveRequest) returns (google.protobuf.Empty) {
     }
 }

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -704,13 +704,13 @@ message TaskKillRequest {
 }
 
 message TaskMoveRequest {
-    /// (Required) Job which is the source of the task.
+    /// (Required) Source Job(Service) distinct from target job which is the source of the task.
     string sourceJobId = 1;
 
-    /// (Required) Job which is the recipient of the task.
+    /// (Required) Target Job(Service) distinct from source job which is the recipient of the task.
     string targetJobId = 2;
 
-    /// (Required) Task to move.
+    /// (Required) Task to move. Task must be in started state.
     string taskId = 3;
 }
 

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -776,7 +776,9 @@ service JobManagementService {
     rpc KillTask (TaskKillRequest) returns (google.protobuf.Empty) {
     }
 
-    /// Move a task from one job to another.
+    /// Move a task from one job to another. Source and destination jobs must be compatible, as defined by:
+    // - Both are service jobs.
+    // - Both their JobDescriptors have the exact same Container definition (image, entryPoint, command, env, etc).
     rpc MoveTask (TaskMoveRequest) returns (google.protobuf.Empty) {
     }
 }

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -704,11 +704,14 @@ message TaskKillRequest {
 }
 
 message TaskMoveRequest {
-    /// (Required) Task to move.
-    string taskId = 1;
+    /// (Required) Job which is the source of the task.
+    string sourceJobId = 1;
 
     /// (Required) Job which is the recipient of the task.
     string targetJobId = 2;
+
+    /// (Required) Task to move.
+    string taskId = 3;
 }
 
 service JobManagementService {


### PR DESCRIPTION
### Description of the Change

API for moving tasks between two compatible jobs.

@amitaekbote @tbak FYI I rebased the original branch onto `master`, so your local copies may be incompatible now.