### PR TITLE
Add RatePerInterval disruption budget rate policy

### DIFF
--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -222,9 +222,16 @@ message JobDisruptionBudget {
         double maxPercentageOfContainersRelocatedInHour = 1;
     }
 
+    /// Allow up to the given amount of relocations per the time interval.
+    message RatePerInterval {
+        uint64 intervalMs = 1;
+        uint32 limitPerInterval = 2;
+    }
+
     oneof Rate {
         RateUnlimited rateUnlimited = 5;
         RatePercentagePerHour ratePercentagePerHour = 6;
+        RatePerInterval ratePerInterval = 9;
     }
 
     /// (Optional) Time window to which relocation process is restricted.


### PR DESCRIPTION
To cover use cases like: terminate 1 container every 5 min.
The latter cannot be expressed now with the existing DisruptionBudgetRate policies.
