### PR TITLE
Add RatePercentagePerInterval rate policy to the job disruption budget

### DIFF
--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -228,9 +228,12 @@ message JobDisruptionBudget {
         uint32 limitPerInterval = 2;
     }
 
-    /// Percentage of containers that can be relocated within a time interval. For example, setting
-    /// interval to 60000 (1 minute) and ratePercentagePerInterval to 5 (5%) would allow only for up to 5% of all
-    // containers to be relocated every minute, given the other criteria are met.
+    /// Percentage of containers that can be relocated within a time interval. The number of containers is determined
+    // during each evaluation, and the number is based on the current desired job size. If the job size changes, the percentage of containers
+    /// changes accordingly. For example, setting / interval to 60000 (1 minute) and ratePercentagePerInterval to 5 (5%)
+    /// would allow only for up to 5% of all containers to be relocated every minute, given the other criteria are met.
+    /// For a job with a desired size of 100, 5 container relocations per minute would be allowed. If the desired job size changes
+    /// to 200, the relocation rate increases to 10 containers per minute.
     message RatePercentagePerInterval {
         uint64 intervalMs = 1;
         double percentageLimitPerInterval = 2;

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -228,10 +228,19 @@ message JobDisruptionBudget {
         uint32 limitPerInterval = 2;
     }
 
+    /// Percentage of containers that can be relocated within a time interval. For example, setting
+    /// interval to 60000 (1 minute) and ratePercentagePerInterval to 5 (5%) would allow only for up to 5% of all
+    // containers to be relocated every minute, given the other criteria are met.
+    message RatePercentagePerInterval {
+        uint64 intervalMs = 1;
+        double percentageLimitPerInterval = 2;
+    }
+
     oneof Rate {
         RateUnlimited rateUnlimited = 5;
         RatePercentagePerHour ratePercentagePerHour = 6;
         RatePerInterval ratePerInterval = 9;
+        RatePercentagePerInterval ratePercentagePerInterval = 10;
     }
 
     /// (Optional) Time window to which relocation process is restricted.

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -229,7 +229,7 @@ message JobDisruptionBudget {
     }
 
     /// Percentage of containers that can be relocated within a time interval. The number of containers is determined
-    // during each evaluation, and the number is based on the current desired job size. If the job size changes, the percentage of containers
+    /// during each evaluation, and the number is based on the current desired job size. If the job size changes, the percentage of containers
     /// changes accordingly. For example, setting / interval to 60000 (1 minute) and ratePercentagePerInterval to 5 (5%)
     /// would allow only for up to 5% of all containers to be relocated every minute, given the other criteria are met.
     /// For a job with a desired size of 100, 5 container relocations per minute would be allowed. If the desired job size changes


### PR DESCRIPTION
It is a counterpart to `RatePerInterval` for jobs with varying sizes or having auto scale policy rules.