### PR TITLE
Add shared memory size option to ContainerInfo

### DIFF
--- a/src/main/proto/netflix/titus/agent.proto
+++ b/src/main/proto/netflix/titus/agent.proto
@@ -284,6 +284,9 @@ message ContainerInfo {
 
     // Used internally by the agent to store information about a running container
     optional RunningContainerInfo runState = 39;
+
+    /// (Optional) Amount of shared memory to allocate (must be <= memoryMB)
+    optional uint32 shmSizeMB = 40;
 }
 
 // For the identity client to query the metadata server to confirm the


### PR DESCRIPTION
For configuring the size of /dev/shm of a container.