### PR TITLE
Remove family and prefixlength from address

### DIFF
--- a/src/main/proto/netflix/titus/titus_vpc_api.proto
+++ b/src/main/proto/netflix/titus/titus_vpc_api.proto
@@ -13,10 +13,7 @@ enum Family {
 };
 
 message Address {
-    Family family = 1;
-    string address = 2;
-    // This is the cidr Prefix length, 0-32 bits for IPv4, and 0-128 bits for IPv6.
-    uint32 prefixLength = 3;
+    string address = 1;
 }
 
 message AddressLocation {
@@ -41,6 +38,7 @@ message SignedAddressAllocation {
 
 message AllocateAddressRequest {
     AddressAllocation addressAllocation = 1;
+    Family family = 2;
 };
 
 


### PR DESCRIPTION
Prefixlength should only be required for the titus executor
internal APIs. In addition, family only makes sense to expose
at allocation time, but not general purpose usage, because
users should parse the IP, and check if it : delimited, or . delimited.
