### PR TITLE
update job capacity API that supports providing only new values

### DIFF
--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -176,6 +176,23 @@ message Capacity {
     uint32 desired = 3;
 }
 
+message JobCapacity {
+    // (Optional) Minimum number of tasks to run (min >= 0)
+    oneof Min {
+        uint32 minValue = 1;
+    }
+
+    // (Optional) Maximum number of tasks that can be run (max >= desired)
+    oneof Max {
+        uint32 maxValue = 2;
+    }
+
+    // (Optional) Desired number of tasks to run (min <= desired <= max)
+    oneof Desired {
+        uint32 desiredValue = 3;
+    }
+}
+
 /// Job disruption budget, associated (optionally) with a job.
 message JobDisruptionBudget {
 
@@ -672,6 +689,11 @@ message JobCapacityUpdate {
     Capacity Capacity = 2;
 }
 
+message JobCapacityValues {
+    string jobId = 1;
+    JobCapacity jobCapacity = 2;
+}
+
 message JobStatusUpdate {
     string id = 1;
     bool enableStatus = 2;
@@ -780,6 +802,11 @@ service JobManagementService {
     /// Modify the number of instances for a service job.
     rpc UpdateJobCapacity (JobCapacityUpdate) returns (google.protobuf.Empty) {
     }
+
+    /// Modify job capacity for a service job. It allows you to specify only values (min / max / desired) that need to be updated.
+    rpc UpdateJobCapacityValues (JobCapacityValues) returns (google.protobuf.Empty) {
+    }
+
 
     /// Mark a job as enabled or disabled. Disabled jobs are not auto-scaled.
     rpc UpdateJobStatus (JobStatusUpdate) returns (google.protobuf.Empty) {

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -7,6 +7,7 @@ package com.netflix.titus;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
 import "netflix/titus/titus_base.proto";
 
 option java_multiple_files = true;
@@ -176,21 +177,15 @@ message Capacity {
     uint32 desired = 3;
 }
 
-message JobCapacity {
+message JobCapacityWithOptionalAttributes {
     // (Optional) Minimum number of tasks to run (min >= 0)
-    oneof Min {
-        uint32 minValue = 1;
-    }
+    google.protobuf.UInt32Value min = 1;
 
     // (Optional) Maximum number of tasks that can be run (max >= desired)
-    oneof Max {
-        uint32 maxValue = 2;
-    }
+    google.protobuf.UInt32Value max = 2;
 
     // (Optional) Desired number of tasks to run (min <= desired <= max)
-    oneof Desired {
-        uint32 desiredValue = 3;
-    }
+    google.protobuf.UInt32Value desired = 3;
 }
 
 /// Job disruption budget, associated (optionally) with a job.
@@ -689,9 +684,9 @@ message JobCapacityUpdate {
     Capacity Capacity = 2;
 }
 
-message JobCapacityValues {
+message JobCapacityUpdateWithOptionalAttributes {
     string jobId = 1;
-    JobCapacity jobCapacity = 2;
+    JobCapacityWithOptionalAttributes jobCapacityWithOptionalAttributes = 2;
 }
 
 message JobStatusUpdate {
@@ -804,7 +799,7 @@ service JobManagementService {
     }
 
     /// Modify job capacity for a service job. It allows you to specify only values (min / max / desired) that need to be updated.
-    rpc UpdateJobCapacityValues (JobCapacityValues) returns (google.protobuf.Empty) {
+    rpc UpdateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes) returns (google.protobuf.Empty) {
     }
 
 


### PR DESCRIPTION
### New job update API

A new job update API that does not need a full capacity specification (min/max/desired). Only the values that need an update can be provided. It enables us to update only one (or more) capacity attributes to be modified atomically avoiding the read-modify-write workflow for job capacity update operation.