### PR TITLE
Add signed IP address allocations to container resources

### DIFF
--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -268,3 +268,46 @@ message ContainerHealthProvider {
     /// (Optional) Attributes to be used by the provider.
     map<string, string> attributes = 3;
 }
+
+/// An IP address.
+message Address {
+
+    /// (Required) The IP address.
+    string address = 1;
+}
+
+/// The location within the VPC where the address exists.
+message AddressLocation {
+
+    /// (Required) Region the address exists in.
+    string region = 1;
+
+    /// (Required) Availability zone the address exists in.
+    string availabilityZone = 2;
+
+    /// (Required) Subnet the address exists in.
+    string subnetId = 3;
+}
+
+/// An IP address allocation from the Titus VPC service.
+message AddressAllocation {
+
+    /// (Required) The location of the address within the VPC.
+    AddressLocation addressLocation = 1;
+
+    /// (Required) A valid UUID4. It should be set during VPC service allocation, if unset, one will be set for you.
+    string uuid = 2;
+
+    /// (Required) The VPC IP address. The address.address must be unset when requesting an allocation from the VPC service.
+    Address address = 3;
+};
+
+/// An IP address allocation signed by the Titus VPC service.
+message SignedAddressAllocation {
+
+    /// (Required) The IP address and metadata taht was allocated.
+    AddressAllocation addressAllocation = 1;
+
+    // (Required) This is an x509v3 signed version of the address allocation.
+    bytes signedAddressAllocation = 2;
+};

--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -298,7 +298,7 @@ message AddressAllocation {
 /// An IP address allocation signed by the Titus VPC service.
 message SignedAddressAllocation {
 
-    /// (Required) The IP address and metadata taht was allocated.
+    /// (Required) The IP address and metadata that was allocated.
     AddressAllocation addressAllocation = 1;
 
     // (Required) This is an x509v3 signed version of the address allocation.

--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -269,13 +269,6 @@ message ContainerHealthProvider {
     map<string, string> attributes = 3;
 }
 
-/// An IP address.
-message Address {
-
-    /// (Required) The IP address.
-    string address = 1;
-}
-
 /// The location within the VPC where the address exists.
 message AddressLocation {
 
@@ -298,8 +291,8 @@ message AddressAllocation {
     /// (Required) A valid UUID4. It should be set during VPC service allocation, if unset, one will be set for you.
     string uuid = 2;
 
-    /// (Required) The VPC IP address. The address.address must be unset when requesting an allocation from the VPC service.
-    Address address = 3;
+    /// (Required) The VPC IP address. The address must be unset when requesting an allocation from the VPC service.
+    string address = 3;
 };
 
 /// An IP address allocation signed by the Titus VPC service.

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -8,6 +8,7 @@ package com.netflix.titus;
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 import "netflix/titus/titus_base.proto";
+import "netflix/titus/titus_vpc_api.proto";
 
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
@@ -109,6 +110,9 @@ message ContainerResources {
     /// (Optional) Size of shared memory /dev/shm. If not set, a default value will be provided. A provided value
     // must be less than or equal to amount of memory allocated.
     uint32 shmSizeMB = 8;
+
+    /// (Optional) IP addresses allocated from Titus VPC IP service to be assigned to tasks.
+    repeated SignedAddressAllocation signedAddressAllocations = 9;
 }
 
 /// Container security profile.

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -8,7 +8,6 @@ package com.netflix.titus;
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 import "netflix/titus/titus_base.proto";
-import "netflix/titus/titus_vpc_api.proto";
 
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";

--- a/src/main/proto/netflix/titus/titus_vpc_api.proto
+++ b/src/main/proto/netflix/titus/titus_vpc_api.proto
@@ -24,7 +24,7 @@ message AllocateAddressResponse {
 
 message GetAllocationRequest {
     oneof searchParameter {
-        Address address = 1;
+        string address = 1;
         string uuid = 2;
     }
 };

--- a/src/main/proto/netflix/titus/titus_vpc_api.proto
+++ b/src/main/proto/netflix/titus/titus_vpc_api.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package com.netflix.titus;
 
 import "google/protobuf/timestamp.proto";
+import "netflix/titus/titus_base.proto";
 
 option go_package = "titus";
 
@@ -12,35 +13,10 @@ enum Family {
     FAMILY_V6 = 2;
 };
 
-message Address {
-    string address = 1;
-}
-
-message AddressLocation {
-    string region = 1;
-    string availabilityZone = 2;
-    string subnetId = 3;
-}
-
-message AddressAllocation {
-    AddressLocation addressLocation = 1;
-    // A valid UUID4. It should be set during allocation, if unset, one will be set for you.
-    string uuid = 2;
-    // address.address must be unset when requesting an allocation
-    Address address = 3;
-};
-
-message SignedAddressAllocation {
-    AddressAllocation addressAllocation = 1;
-    // This is an x509v3 signed version of the Address allocation.
-    bytes signedAddressAllocation = 2;
-}
-
 message AllocateAddressRequest {
     AddressAllocation addressAllocation = 1;
     Family family = 2;
 };
-
 
 message AllocateAddressResponse {
     SignedAddressAllocation signedAddressAllocation = 1;


### PR DESCRIPTION
Allows IP allocations from the new Titus VPC service to be assigned to a job's container resources.