### PR TITLE
Remove `partialResult` field from the `Pagination` message

### DIFF
--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -101,10 +101,6 @@ message Pagination {
     /// Position of the cursor relative to totalItems. It can be used to determine what pageNumber would overlap with a
     // cursor, or to provide an idea of progress when walking all pages. Valid values are [0, totalItems-1].
     int32 cursorPosition = 6;
-
-    /// Whether or not this response is a partial result. While the information in a partial result will be correct,
-    /// there may be missing information so the client should not treat the absence of data as correct.
-    bool partialResult = 7;
 }
 
 /// Retry polices.


### PR DESCRIPTION
which has been added prematurely.
