### PR TITLE
Add IPv6 address to task identity document

### DIFF
--- a/src/main/proto/netflix/titus/agent.proto
+++ b/src/main/proto/netflix/titus/agent.proto
@@ -316,6 +316,9 @@ message TaskIdentity {
 
     // (Required) IP address of container
     optional string ipv4Address = 4;
+
+    // (Optional) IPv6 address of container
+    optional string ipv6Address = 5;
 }
 
 enum SignatureAlgorithm {


### PR DESCRIPTION
Moving to IPv6 requires adding the v6 address to the task identity document.