### PR TITLE
RPCs to verify subnets, security groups and accountId

### DIFF
--- a/src/main/proto/netflix/titus/titus_vpc_api.proto
+++ b/src/main/proto/netflix/titus/titus_vpc_api.proto
@@ -48,8 +48,41 @@ message ValidationRequest {
 message ValidationResponse {
 };
 
+message ValidationFailures {
+    repeated ValidationFailure failures = 1;
+}
+
+message ValidationFailure {
+    // Common error codes.
+    string errorCode = 1;
+
+    // Failure details.
+    string errorMessage = 2;
+}
+
+message ParametersValidationRequest {
+
+    string accountId = 1;
+
+    repeated string subnets = 2;
+
+    repeated string securityGroups = 3;
+};
+
+message ParametersValidationResponse {
+    message Success {
+    };
+
+    oneof Result {
+        Success success = 1;
+
+        ValidationFailures failures = 2;
+    }
+};
+
 service ValidatorIPService {
     rpc ValidateAllocation (ValidationRequest) returns (ValidationResponse);
+    rpc ValidateAllocationParameters (ParametersValidationRequest) returns (ParametersValidationResponse);
 }
 
 // V2 API

--- a/src/main/proto/netflix/titus/titus_vpc_api.proto
+++ b/src/main/proto/netflix/titus/titus_vpc_api.proto
@@ -48,18 +48,6 @@ message ValidationRequest {
 message ValidationResponse {
 };
 
-message ValidationFailures {
-    repeated ValidationFailure failures = 1;
-}
-
-message ValidationFailure {
-    // Common error codes.
-    string errorCode = 1;
-
-    // Failure details.
-    string errorMessage = 2;
-}
-
 message ParametersValidationRequest {
 
     string accountId = 1;
@@ -70,14 +58,36 @@ message ParametersValidationRequest {
 };
 
 message ParametersValidationResponse {
-    message Success {
+
+    enum ValidationErrorCode {
+        Unknown = 0;
+        SubnetNotFound = 1;
+        SecurityGroupNotFound = 2;
+        AccountIdUnsupported = 3;
+        SubnetDoesNotMatchAccountId = 4;
+        SubnetsTooDiverse = 5;
+    }
+
+    message ValidationFailure {
+        // Validation error code.
+        oneof errorCodeOneOf {
+            ValidationErrorCode errorCode = 1;
+        }
+
+        // Failure details.
+        string errorMessage = 2;
     };
 
-    oneof Result {
-        Success success = 1;
+    message ValidationFailures {
 
-        ValidationFailures failures = 2;
+        // One or more validation errors
+        repeated ValidationFailure failure = 1;
+
     }
+
+    // If the following structure does not contain any failure elements, it implies a validation success
+    ValidationFailures failures = 1;
+
 };
 
 service ValidatorIPService {

--- a/src/main/proto/netflix/titus/titus_vpc_api.proto
+++ b/src/main/proto/netflix/titus/titus_vpc_api.proto
@@ -59,35 +59,38 @@ message ParametersValidationRequest {
 
 message ParametersValidationResponse {
 
-    enum ValidationErrorCode {
-        Unknown = 0;
-        SubnetNotFound = 1;
-        SecurityGroupNotFound = 2;
-        AccountIdUnsupported = 3;
-        SubnetDoesNotMatchAccountId = 4;
-        SubnetsTooDiverse = 5;
-    }
-
-    message ValidationFailure {
-        // Validation error code.
-        oneof errorCodeOneOf {
-            ValidationErrorCode errorCode = 1;
-        }
-
-        // Failure details.
-        string errorMessage = 2;
+    message UnknownFailure {
+        string failure = 1;
+    };
+    message SubnetNotFound {
+        string subnetId = 1;
+    };
+    message SecurityGroupNotFound {
+        string securityGroup = 1;
+    };
+    message AccountIdUnsupported {
+        string accountId = 1;
+    };
+    message SubnetDoesNotMatchAccountId {
+        string subnetId = 1;
+    };
+    message SubnetsTooDiverse {
+        string subnetId = 1;
     };
 
-    message ValidationFailures {
-
-        // One or more validation errors
-        repeated ValidationFailure failure = 1;
-
-    }
+    message ValidationFailure {
+        oneof failureOneOf {
+            UnknownFailure unknownFailure = 1;
+            SubnetNotFound subnetNotFound = 2;
+            SecurityGroupNotFound securityGroupNotFound = 3;
+            AccountIdUnsupported accountIdUnsupported = 4;
+            SubnetDoesNotMatchAccountId subnetDoesNotMatchAccountId = 5;
+            SubnetsTooDiverse subnetsTooDiverse = 6;
+        }
+    };
 
     // If the following structure does not contain any failure elements, it implies a validation success
-    ValidationFailures failures = 1;
-
+    repeated ValidationFailure validationFailures = 1;
 };
 
 service ValidatorIPService {
@@ -99,7 +102,7 @@ service ValidatorIPService {
 message AllocateStaticIPAddressRequest {
     /// Required (The subnet where to allocate the address)
     string subnetId = 1;
-    /// Optional. If specified, and an ID with that already exists, it will return an error. 
+    /// Optional. If specified, and an ID with that already exists, it will return an error.
     /// This allows for idempotent requests.
     string uuid = 2;
     /// Optional. Pool is an indexed column that can be used to select static IPs by.

--- a/src/main/proto/netflix/titus/validator/validator.proto
+++ b/src/main/proto/netflix/titus/validator/validator.proto
@@ -253,5 +253,8 @@ message NetworkParametersValidationResponse {
         ValidationFailures failures = 2;
     }
 
+    // Information about cached data used in the validation process. Some duplicate validation requests
+    // may not be evaluated immediately and a cached response may be served details of which will be
+    // populated in this metadata field.
     CacheMetadata cacheMetadata = 3;
 }

--- a/src/main/proto/netflix/titus/validator/validator.proto
+++ b/src/main/proto/netflix/titus/validator/validator.proto
@@ -35,6 +35,10 @@ service ValidationService {
     // Validates EBS volume.
     rpc ValidateEbsVolume (EbsVolumeValidationRequest) returns (EbsVolumeValidationResponse) {
     }
+
+    // Validate Subnets and SecurityGroups for a given AccountId.
+    rpc ValidateNetworkParameters (NetworkParametersValidationRequest) returns (NetworkParametersValidationResponse) {
+    }
 }
 
 // Information about cached data used in the validation process. Cache is also used for negative results so
@@ -216,6 +220,31 @@ message ImageValidationResponse {
     message Success {
         // If validation was successful, a resolved digest for the image.
         string digest = 1;
+    }
+
+    oneof Result {
+        Success success = 1;
+
+        ValidationFailures failures = 2;
+    }
+
+    CacheMetadata cacheMetadata = 3;
+}
+
+message NetworkParametersValidationRequest {
+
+    // Account Id network address allocation is being requested in.
+    string accountId = 1;
+
+    // Subnets for network address allocation.
+    repeated string subnets = 2;
+
+    // SecurityGroups to check for existence.
+    repeated string securityGroups = 3;
+}
+
+message NetworkParametersValidationResponse {
+    message Success {
     }
 
     oneof Result {


### PR DESCRIPTION
### Description of the Change

Adding RPCs to ValidationService and ValidationIPService (for VPC service) to verify if a given set of accountId, subnets and security groups are valid.