### PR TITLE
Added a new NetworkingConfiguration message to the Job API

### DIFF
--- a/doc/titus-v3-spec.html
+++ b/doc/titus-v3-spec.html
@@ -383,6 +383,10 @@
                 </li>
               
                 <li>
+                  <a href="#com.netflix.titus.NetworkConfiguration"><span class="badge">M</span>NetworkConfiguration</a>
+                </li>
+              
+                <li>
                   <a href="#com.netflix.titus.ObserveJobsQuery"><span class="badge">M</span>ObserveJobsQuery</a>
                 </li>
               
@@ -473,6 +477,10 @@
               
                 <li>
                   <a href="#com.netflix.titus.JobStatus.JobState"><span class="badge">E</span>JobStatus.JobState</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.NetworkConfiguration.NetworkMode"><span class="badge">E</span>NetworkConfiguration.NetworkMode</a>
                 </li>
               
                 <li>
@@ -1426,6 +1434,13 @@ own unique identifier for a job (see JobGroupInfo for more information). </p></t
                   <td><p>(Optional) Job disruption budget. If not defined, a job type specific (batch or service) default is set. </p></td>
                 </tr>
               
+                <tr>
+                  <td>networkConfiguration</td>
+                  <td><a href="#com.netflix.titus.NetworkConfiguration">NetworkConfiguration</a></td>
+                  <td></td>
+                  <td><p>(Optional) Networking configuration. If not defined, sane defaults are provided by the backend. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -2309,6 +2324,30 @@ For example: tasks.taskId rule will result in including just this value when enc
 
         
       
+        <h3 id="com.netflix.titus.NetworkConfiguration">NetworkConfiguration</h3>
+        <p>Network settings for tasks launched by this job</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>networkMode</td>
+                  <td><a href="#com.netflix.titus.NetworkConfiguration.NetworkMode">NetworkConfiguration.NetworkMode</a></td>
+                  <td></td>
+                  <td><p>Sets the overall network mode for all containers for a Task launched by this job </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="com.netflix.titus.ObserveJobsQuery">ObserveJobsQuery</h3>
         <p>The filtering criteria is applied to both Job and Task events. If a criteria applies to task fields, the stream will</p><p>include both task events matching it, and events for jobs with tasks that match it. The opposite is also true, e.g.:</p><p>a criteria on applicationName (a job field) will include both job events matching it, and events for tasks belonging</p><p>to a job that matches it.</p><p>---------------------------------------------------</p><p>Filtering criteria</p>
 
@@ -3177,6 +3216,49 @@ skipSystemFailures - a filter for finished tasks only (does not affect non-finis
                 <td>Finished</td>
                 <td>2</td>
                 <td><p>A job has no running tasks, and new tasks cannot be created. Job policy update operations are not allowed.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="com.netflix.titus.NetworkConfiguration.NetworkMode">NetworkConfiguration.NetworkMode</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>UnknownNetworkMode</td>
+                <td>0</td>
+                <td><p>Unknown, the backend will have to chose a sane default base on other inputs</p></td>
+              </tr>
+            
+              <tr>
+                <td>Ipv4Only</td>
+                <td>1</td>
+                <td><p>IPv4 only means the task will not get an ipv6 address, and will only get a unique v4.</p></td>
+              </tr>
+            
+              <tr>
+                <td>Ipv6AndIpv4</td>
+                <td>2</td>
+                <td><p>IPv6 And IPv4 (True Dual Stack), each task gets a unique v6 and v4 address.</p></td>
+              </tr>
+            
+              <tr>
+                <td>Ipv6AndIpv4Fallback</td>
+                <td>3</td>
+                <td><p>IPv6 and IPv4 Fallback uses the Titus IPv4 &#34;transition mechanism&#34; to give v4
+connectivity transparently without providing every container their own IPv4 address.
+From a spinnaker/task perspective, only an IPv6 address is allocated to the task.</p></td>
+              </tr>
+            
+              <tr>
+                <td>Ipv6Only</td>
+                <td>4</td>
+                <td><p>IPv6 Only is for true believers, no IPv4 connectivity is provided.</p></td>
               </tr>
             
           </tbody>

--- a/doc/titus-v3-spec.md
+++ b/doc/titus-v3-spec.md
@@ -55,6 +55,7 @@
     - [MigrationPolicy](#com.netflix.titus.MigrationPolicy)
     - [MigrationPolicy.SelfManaged](#com.netflix.titus.MigrationPolicy.SelfManaged)
     - [MigrationPolicy.SystemDefault](#com.netflix.titus.MigrationPolicy.SystemDefault)
+    - [NetworkConfiguration](#com.netflix.titus.NetworkConfiguration)
     - [ObserveJobsQuery](#com.netflix.titus.ObserveJobsQuery)
     - [ObserveJobsQuery.FilteringCriteriaEntry](#com.netflix.titus.ObserveJobsQuery.FilteringCriteriaEntry)
     - [Owner](#com.netflix.titus.Owner)
@@ -79,6 +80,7 @@
     - [TaskStatus](#com.netflix.titus.TaskStatus)
   
     - [JobStatus.JobState](#com.netflix.titus.JobStatus.JobState)
+    - [NetworkConfiguration.NetworkMode](#com.netflix.titus.NetworkConfiguration.NetworkMode)
     - [TaskStatus.TaskState](#com.netflix.titus.TaskStatus.TaskState)
   
     - [JobManagementService](#com.netflix.titus.JobManagementService)
@@ -497,6 +499,7 @@ Job descriptor contains the full job specification (batch or service) that is us
 | batch | [BatchJobSpec](#com.netflix.titus.BatchJobSpec) |  | Batch job specific descriptor. |
 | service | [ServiceJobSpec](#com.netflix.titus.ServiceJobSpec) |  | Service job specific descriptor. |
 | disruptionBudget | [JobDisruptionBudget](#com.netflix.titus.JobDisruptionBudget) |  | (Optional) Job disruption budget. If not defined, a job type specific (batch or service) default is set. |
+| networkConfiguration | [NetworkConfiguration](#com.netflix.titus.NetworkConfiguration) |  | (Optional) Networking configuration. If not defined, sane defaults are provided by the backend. |
 
 
 
@@ -958,6 +961,21 @@ The system default migration policy.
 
 
 
+<a name="com.netflix.titus.NetworkConfiguration"></a>
+
+### NetworkConfiguration
+Network settings for tasks launched by this job
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| networkMode | [NetworkConfiguration.NetworkMode](#com.netflix.titus.NetworkConfiguration.NetworkMode) |  | Sets the overall network mode for all containers for a Task launched by this job |
+
+
+
+
+
+
 <a name="com.netflix.titus.ObserveJobsQuery"></a>
 
 ### ObserveJobsQuery
@@ -1341,6 +1359,21 @@ State information associated with a job.
 | Accepted | 0 | A job is persisted in Titus and is ready to be scheduled. |
 | KillInitiated | 1 | A job still has running tasks that were requested to be terminated. No more tasks for this job are deployed. Job policy update operations are not allowed. |
 | Finished | 2 | A job has no running tasks, and new tasks cannot be created. Job policy update operations are not allowed. |
+
+
+
+<a name="com.netflix.titus.NetworkConfiguration.NetworkMode"></a>
+
+### NetworkConfiguration.NetworkMode
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UnknownNetworkMode | 0 | Unknown, the backend will have to chose a sane default base on other inputs |
+| Ipv4Only | 1 | IPv4 only means the task will not get an ipv6 address, and will only get a unique v4. |
+| Ipv6AndIpv4 | 2 | IPv6 And IPv4 (True Dual Stack), each task gets a unique v6 and v4 address. |
+| Ipv6AndIpv4Fallback | 3 | IPv6 and IPv4 Fallback uses the Titus IPv4 &#34;transition mechanism&#34; to give v4 connectivity transparently without providing every container their own IPv4 address. From a spinnaker/task perspective, only an IPv6 address is allocated to the task. |
+| Ipv6Only | 4 | IPv6 Only is for true believers, no IPv4 connectivity is provided. |
 
 
 

--- a/doc/titus-vpc-api-spec.html
+++ b/doc/titus-vpc-api-spec.html
@@ -259,6 +259,42 @@
                 </li>
               
                 <li>
+                  <a href="#com.netflix.titus.ParametersValidationRequest"><span class="badge">M</span>ParametersValidationRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse"><span class="badge">M</span>ParametersValidationResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse.AccountIdUnsupported"><span class="badge">M</span>ParametersValidationResponse.AccountIdUnsupported</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse.SecurityGroupNotFound"><span class="badge">M</span>ParametersValidationResponse.SecurityGroupNotFound</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse.SubnetDoesNotMatchAccountId"><span class="badge">M</span>ParametersValidationResponse.SubnetDoesNotMatchAccountId</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse.SubnetNotFound"><span class="badge">M</span>ParametersValidationResponse.SubnetNotFound</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse.SubnetsTooDiverse"><span class="badge">M</span>ParametersValidationResponse.SubnetsTooDiverse</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse.UnknownFailure"><span class="badge">M</span>ParametersValidationResponse.UnknownFailure</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.ParametersValidationResponse.ValidationFailure"><span class="badge">M</span>ParametersValidationResponse.ValidationFailure</a>
+                </li>
+              
+                <li>
                   <a href="#com.netflix.titus.SetPoolRequest"><span class="badge">M</span>SetPoolRequest</a>
                 </li>
               
@@ -912,6 +948,271 @@
 
         
       
+        <h3 id="com.netflix.titus.ParametersValidationRequest">ParametersValidationRequest</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>accountId</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>subnets</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>securityGroups</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse">ParametersValidationResponse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>validationFailures</td>
+                  <td><a href="#com.netflix.titus.ParametersValidationResponse.ValidationFailure">ParametersValidationResponse.ValidationFailure</a></td>
+                  <td>repeated</td>
+                  <td><p>If the following structure does not contain any failure elements, it implies a validation success </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse.AccountIdUnsupported">ParametersValidationResponse.AccountIdUnsupported</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>accountId</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse.SecurityGroupNotFound">ParametersValidationResponse.SecurityGroupNotFound</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>securityGroup</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse.SubnetDoesNotMatchAccountId">ParametersValidationResponse.SubnetDoesNotMatchAccountId</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>subnetId</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse.SubnetNotFound">ParametersValidationResponse.SubnetNotFound</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>subnetId</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse.SubnetsTooDiverse">ParametersValidationResponse.SubnetsTooDiverse</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>subnetId</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse.UnknownFailure">ParametersValidationResponse.UnknownFailure</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>failure</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.ParametersValidationResponse.ValidationFailure">ParametersValidationResponse.ValidationFailure</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>unknownFailure</td>
+                  <td><a href="#com.netflix.titus.ParametersValidationResponse.UnknownFailure">ParametersValidationResponse.UnknownFailure</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>subnetNotFound</td>
+                  <td><a href="#com.netflix.titus.ParametersValidationResponse.SubnetNotFound">ParametersValidationResponse.SubnetNotFound</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>securityGroupNotFound</td>
+                  <td><a href="#com.netflix.titus.ParametersValidationResponse.SecurityGroupNotFound">ParametersValidationResponse.SecurityGroupNotFound</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>accountIdUnsupported</td>
+                  <td><a href="#com.netflix.titus.ParametersValidationResponse.AccountIdUnsupported">ParametersValidationResponse.AccountIdUnsupported</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>subnetDoesNotMatchAccountId</td>
+                  <td><a href="#com.netflix.titus.ParametersValidationResponse.SubnetDoesNotMatchAccountId">ParametersValidationResponse.SubnetDoesNotMatchAccountId</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>subnetsTooDiverse</td>
+                  <td><a href="#com.netflix.titus.ParametersValidationResponse.SubnetsTooDiverse">ParametersValidationResponse.SubnetsTooDiverse</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="com.netflix.titus.SetPoolRequest">SetPoolRequest</h3>
         <p></p>
 
@@ -1269,6 +1570,13 @@
                 <td>ValidateAllocation</td>
                 <td><a href="#com.netflix.titus.ValidationRequest">ValidationRequest</a></td>
                 <td><a href="#com.netflix.titus.ValidationResponse">ValidationResponse</a></td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>ValidateAllocationParameters</td>
+                <td><a href="#com.netflix.titus.ParametersValidationRequest">ParametersValidationRequest</a></td>
+                <td><a href="#com.netflix.titus.ParametersValidationResponse">ParametersValidationResponse</a></td>
                 <td><p></p></td>
               </tr>
             

--- a/doc/titus-vpc-api-spec.md
+++ b/doc/titus-vpc-api-spec.md
@@ -24,6 +24,15 @@
     - [GetStaticIPAddressResponse](#com.netflix.titus.GetStaticIPAddressResponse)
     - [GetStaticIPAddressesRequest](#com.netflix.titus.GetStaticIPAddressesRequest)
     - [GetStaticIPAddressesResponse](#com.netflix.titus.GetStaticIPAddressesResponse)
+    - [ParametersValidationRequest](#com.netflix.titus.ParametersValidationRequest)
+    - [ParametersValidationResponse](#com.netflix.titus.ParametersValidationResponse)
+    - [ParametersValidationResponse.AccountIdUnsupported](#com.netflix.titus.ParametersValidationResponse.AccountIdUnsupported)
+    - [ParametersValidationResponse.SecurityGroupNotFound](#com.netflix.titus.ParametersValidationResponse.SecurityGroupNotFound)
+    - [ParametersValidationResponse.SubnetDoesNotMatchAccountId](#com.netflix.titus.ParametersValidationResponse.SubnetDoesNotMatchAccountId)
+    - [ParametersValidationResponse.SubnetNotFound](#com.netflix.titus.ParametersValidationResponse.SubnetNotFound)
+    - [ParametersValidationResponse.SubnetsTooDiverse](#com.netflix.titus.ParametersValidationResponse.SubnetsTooDiverse)
+    - [ParametersValidationResponse.UnknownFailure](#com.netflix.titus.ParametersValidationResponse.UnknownFailure)
+    - [ParametersValidationResponse.ValidationFailure](#com.netflix.titus.ParametersValidationResponse.ValidationFailure)
     - [SetPoolRequest](#com.netflix.titus.SetPoolRequest)
     - [SetPoolResponse](#com.netflix.titus.SetPoolResponse)
     - [StaticIPAddress](#com.netflix.titus.StaticIPAddress)
@@ -358,6 +367,148 @@ This is really only meant to be used by (the) control plane(s)
 
 
 
+<a name="com.netflix.titus.ParametersValidationRequest"></a>
+
+### ParametersValidationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| accountId | [string](#string) |  |  |
+| subnets | [string](#string) | repeated |  |
+| securityGroups | [string](#string) | repeated |  |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse"></a>
+
+### ParametersValidationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| validationFailures | [ParametersValidationResponse.ValidationFailure](#com.netflix.titus.ParametersValidationResponse.ValidationFailure) | repeated | If the following structure does not contain any failure elements, it implies a validation success |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse.AccountIdUnsupported"></a>
+
+### ParametersValidationResponse.AccountIdUnsupported
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| accountId | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse.SecurityGroupNotFound"></a>
+
+### ParametersValidationResponse.SecurityGroupNotFound
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| securityGroup | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse.SubnetDoesNotMatchAccountId"></a>
+
+### ParametersValidationResponse.SubnetDoesNotMatchAccountId
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| subnetId | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse.SubnetNotFound"></a>
+
+### ParametersValidationResponse.SubnetNotFound
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| subnetId | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse.SubnetsTooDiverse"></a>
+
+### ParametersValidationResponse.SubnetsTooDiverse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| subnetId | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse.UnknownFailure"></a>
+
+### ParametersValidationResponse.UnknownFailure
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| failure | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="com.netflix.titus.ParametersValidationResponse.ValidationFailure"></a>
+
+### ParametersValidationResponse.ValidationFailure
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| unknownFailure | [ParametersValidationResponse.UnknownFailure](#com.netflix.titus.ParametersValidationResponse.UnknownFailure) |  |  |
+| subnetNotFound | [ParametersValidationResponse.SubnetNotFound](#com.netflix.titus.ParametersValidationResponse.SubnetNotFound) |  |  |
+| securityGroupNotFound | [ParametersValidationResponse.SecurityGroupNotFound](#com.netflix.titus.ParametersValidationResponse.SecurityGroupNotFound) |  |  |
+| accountIdUnsupported | [ParametersValidationResponse.AccountIdUnsupported](#com.netflix.titus.ParametersValidationResponse.AccountIdUnsupported) |  |  |
+| subnetDoesNotMatchAccountId | [ParametersValidationResponse.SubnetDoesNotMatchAccountId](#com.netflix.titus.ParametersValidationResponse.SubnetDoesNotMatchAccountId) |  |  |
+| subnetsTooDiverse | [ParametersValidationResponse.SubnetsTooDiverse](#com.netflix.titus.ParametersValidationResponse.SubnetsTooDiverse) |  |  |
+
+
+
+
+
+
 <a name="com.netflix.titus.SetPoolRequest"></a>
 
 ### SetPoolRequest
@@ -536,6 +687,7 @@ If the tag is unset, then do not set it
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | ValidateAllocation | [ValidationRequest](#com.netflix.titus.ValidationRequest) | [ValidationResponse](#com.netflix.titus.ValidationResponse) |  |
+| ValidateAllocationParameters | [ParametersValidationRequest](#com.netflix.titus.ParametersValidationRequest) | [ParametersValidationResponse](#com.netflix.titus.ParametersValidationResponse) |  |
 
  
 

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -71,6 +71,26 @@ message Image {
     string digest = 3;
 }
 
+// Network settings for tasks launched by this job
+message NetworkConfiguration {
+    enum NetworkMode {
+        // Unknown, the backend will have to chose a sane default base on other inputs
+        UnknownNetworkMode = 0;
+        // IPv4 only means the task will not get an ipv6 address, and will only get a unique v4.
+        Ipv4Only = 1;
+        // IPv6 And IPv4 (True Dual Stack), each task gets a unique v6 and v4 address.
+        Ipv6AndIpv4 = 2;
+        // IPv6 and IPv4 Fallback uses the Titus IPv4 "transition mechanism" to give v4
+        // connectivity transparently without providing every container their own IPv4 address.
+        // From a spinnaker/task perspective, only an IPv6 address is allocated to the task.
+        Ipv6AndIpv4Fallback = 3;
+        // IPv6 Only is for true believers, no IPv4 connectivity is provided.
+        Ipv6Only = 4;
+    }
+    // Sets the overall network mode for all containers for a Task launched by this job
+    NetworkMode networkMode = 1;
+}
+
 message ContainerResources {
     /// (Required) Number of CPUs to allocate (must be always > 0, but the actual limit is configurable).
     double cpu = 1;
@@ -391,6 +411,9 @@ message JobDescriptor {
 
     /// (Optional) Job disruption budget. If not defined, a job type specific (batch or service) default is set.
     JobDisruptionBudget disruptionBudget = 10;
+
+    /// (Optional) Networking configuration. If not defined, sane defaults are provided by the backend.
+    NetworkConfiguration networkConfiguration = 11;
 }
 
 /// Composite data structure holding both job state information and the reason of the transition to this state.


### PR DESCRIPTION
This new NetworkingConfiguration section makes room for 2 things:

1. Adding a new way to describe how to configure networking
for jobs without having to set weird (unvalidated) attributes
2. A place to move other network-related settings *out* of
ContainerResources in preparation for Multi-Container workloads.

Only doing step 1 in this PR.
