### PR TITLE
Added new Titus Pod Identity Document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,11 @@ titus-v3-doc:
 		--doc_out=markdown,titus-vpc-api-spec.md:doc \
 		-otitus.protobin --include_imports --include_source_info \
 		src/main/proto/netflix/titus/titus_vpc_api.proto
+	protoc -I/usr/local/include -I. \
+		-Isrc/main/proto \
+		--doc_out=html,titus-agent-api-spec.html:doc \
+		--doc_out=markdown,titus-agent-api-spec.md:doc \
+		-otitus.protobin --include_imports --include_source_info \
+		src/main/proto/netflix/titus/agent.proto
 
 .PHONY: titus-v3-doc

--- a/doc/titus-agent-api-spec.html
+++ b/doc/titus-agent-api-spec.html
@@ -1,0 +1,2168 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>Protocol Documentation</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
+    <style>
+      body {
+        width: 60em;
+        margin: 1em auto;
+        color: #222;
+        font-family: "Ubuntu", sans-serif;
+        padding-bottom: 4em;
+      }
+
+      h1 {
+        font-weight: normal;
+        border-bottom: 1px solid #aaa;
+        padding-bottom: 0.5ex;
+      }
+
+      h2 {
+        border-bottom: 1px solid #aaa;
+        padding-bottom: 0.5ex;
+        margin: 1.5em 0;
+      }
+
+      h3 {
+        font-weight: normal;
+        border-bottom: 1px solid #aaa;
+        padding-bottom: 0.5ex;
+      }
+
+      a {
+        text-decoration: none;
+        color: #567e25;
+      }
+
+      table {
+        width: 100%;
+        font-size: 80%;
+        border-collapse: collapse;
+      }
+
+      thead {
+        font-weight: 700;
+        background-color: #dcdcdc;
+      }
+
+      tbody tr:nth-child(even) {
+        background-color: #fbfbfb;
+      }
+
+      td {
+        border: 1px solid #ccc;
+        padding: 0.5ex 2ex;
+      }
+
+      td p {
+        text-indent: 1em;
+        margin: 0;
+      }
+
+      td p:nth-child(1) {
+        text-indent: 0;  
+      }
+
+       
+      .field-table td:nth-child(1) {  
+        width: 10em;
+      }
+      .field-table td:nth-child(2) {  
+        width: 10em;
+      }
+      .field-table td:nth-child(3) {  
+        width: 6em;
+      }
+      .field-table td:nth-child(4) {  
+        width: auto;
+      }
+
+       
+      .extension-table td:nth-child(1) {  
+        width: 10em;
+      }
+      .extension-table td:nth-child(2) {  
+        width: 10em;
+      }
+      .extension-table td:nth-child(3) {  
+        width: 10em;
+      }
+      .extension-table td:nth-child(4) {  
+        width: 5em;
+      }
+      .extension-table td:nth-child(5) {  
+        width: auto;
+      }
+
+       
+      .enum-table td:nth-child(1) {  
+        width: 10em;
+      }
+      .enum-table td:nth-child(2) {  
+        width: 10em;
+      }
+      .enum-table td:nth-child(3) {  
+        width: auto;
+      }
+
+       
+      .scalar-value-types-table tr {
+        height: 3em;
+      }
+
+       
+      #toc-container ul {
+        list-style-type: none;
+        padding-left: 1em;
+        line-height: 180%;
+        margin: 0;
+      }
+      #toc > li > a {
+        font-weight: bold;
+      }
+
+       
+      .file-heading {
+        width: 100%;
+        display: table;
+        border-bottom: 1px solid #aaa;
+        margin: 4em 0 1.5em 0;
+      }
+      .file-heading h2 {
+        border: none;
+        display: table-cell;
+      }
+      .file-heading a {
+        text-align: right;
+        display: table-cell;
+      }
+
+       
+      .badge {
+        width: 1.6em;
+        height: 1.6em;
+        display: inline-block;
+
+        line-height: 1.6em;
+        text-align: center;
+        font-weight: bold;
+        font-size: 60%;
+
+        color: #89ba48;
+        background-color: #dff0c8;
+
+        margin: 0.5ex 1em 0.5ex -1em;
+        border: 1px solid #fbfbfb;
+        border-radius: 1ex;
+      }
+    </style>
+
+    
+    <link rel="stylesheet" type="text/css" href="stylesheet.css"/>
+  </head>
+
+  <body>
+
+    <h1 id="title">Protocol Documentation</h1>
+
+    <h2>Table of Contents</h2>
+
+    <div id="toc-container">
+      <ul id="toc">
+        
+          
+          <li>
+            <a href="#src%2fmain%2fproto%2fnetflix%2ftitus%2fagent.proto">src/main/proto/netflix/titus/agent.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#messages.CertificateSignature"><span class="badge">M</span>CertificateSignature</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.CertificateStringSignature"><span class="badge">M</span>CertificateStringSignature</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo"><span class="badge">M</span>ContainerInfo</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.Capabilities"><span class="badge">M</span>ContainerInfo.Capabilities</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.EfsConfigInfo"><span class="badge">M</span>ContainerInfo.EfsConfigInfo</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.EnvironmentVariable"><span class="badge">M</span>ContainerInfo.EnvironmentVariable</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.MetatronCreds"><span class="badge">M</span>ContainerInfo.MetatronCreds</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.NetworkConfigInfo"><span class="badge">M</span>ContainerInfo.NetworkConfigInfo</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.PassthroughAttributesEntry"><span class="badge">M</span>ContainerInfo.PassthroughAttributesEntry</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.Process"><span class="badge">M</span>ContainerInfo.Process</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.S3LogLocation"><span class="badge">M</span>ContainerInfo.S3LogLocation</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.TitusProvidedEnvEntry"><span class="badge">M</span>ContainerInfo.TitusProvidedEnvEntry</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.UserProvidedEnvEntry"><span class="badge">M</span>ContainerInfo.UserProvidedEnvEntry</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.RunningContainerInfo"><span class="badge">M</span>RunningContainerInfo</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.StateUpdate"><span class="badge">M</span>StateUpdate</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.StateUpdates"><span class="badge">M</span>StateUpdates</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskIdentity"><span class="badge">M</span>TaskIdentity</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskIdentityDocument"><span class="badge">M</span>TaskIdentityDocument</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskIdentityStringDocument"><span class="badge">M</span>TaskIdentityStringDocument</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskInfo"><span class="badge">M</span>TaskInfo</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskInfo.EnvironmentVariable"><span class="badge">M</span>TaskInfo.EnvironmentVariable</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskPodIdentity"><span class="badge">M</span>TaskPodIdentity</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskPodIdentityDocument"><span class="badge">M</span>TaskPodIdentityDocument</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskStatusData"><span class="badge">M</span>TaskStatusData</a>
+                </li>
+              
+              
+                <li>
+                  <a href="#messages.ContainerInfo.Capabilities.Capability"><span class="badge">E</span>ContainerInfo.Capabilities.Capability</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.EfsConfigInfo.MountPerms"><span class="badge">E</span>ContainerInfo.EfsConfigInfo.MountPerms</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.ImagePullPolicy"><span class="badge">E</span>ContainerInfo.ImagePullPolicy</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.ContainerInfo.SnapshotPolicy"><span class="badge">E</span>ContainerInfo.SnapshotPolicy</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.SignatureAlgorithm"><span class="badge">E</span>SignatureAlgorithm</a>
+                </li>
+              
+                <li>
+                  <a href="#messages.TaskInfo.Status"><span class="badge">E</span>TaskInfo.Status</a>
+                </li>
+              
+              
+              
+            </ul>
+          </li>
+        
+        <li><a href="#scalar-value-types">Scalar Value Types</a></li>
+      </ul>
+    </div>
+
+    
+      
+      <div class="file-heading">
+        <h2 id="src/main/proto/netflix/titus/agent.proto">src/main/proto/netflix/titus/agent.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="messages.CertificateSignature">CertificateSignature</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Raw signature produced from signing input bytes using the
+private key of the titus agent’s certificate. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>algorithm</td>
+                  <td><a href="#messages.SignatureAlgorithm">SignatureAlgorithm</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Signature algorithm used (e.g. SHA512withRSAandMGF1) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>certChain</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>repeated</td>
+                  <td><p>(Required) The agent’s public certificate in DER form, followed by its trust chain. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.CertificateStringSignature">CertificateStringSignature</h3>
+        <p>Version of CertificateSignature that encodes all byte[]s as human-readable strings</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Base64 signature produced from signing input bytes using the
+private key of the titus agent’s certificate. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>algorithm</td>
+                  <td><a href="#messages.SignatureAlgorithm">SignatureAlgorithm</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Signature algorithm used (e.g. SHA512withRSAandMGF1) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>certChain</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>(Required) The agent’s public certificate in DER form, followed by its trust chain. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo">ContainerInfo</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>imageName</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>command</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>deprecated. replaced by entrypointCmd. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>containerPorts</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>version</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> Default: latest</p></td>
+                </tr>
+              
+                <tr>
+                  <td>environmentVariable</td>
+                  <td><a href="#messages.ContainerInfo.EnvironmentVariable">ContainerInfo.EnvironmentVariable</a></td>
+                  <td>repeated</td>
+                  <td><p>deprecated: use userProvidedEnv and titusProvidedEnv instead </p></td>
+                </tr>
+              
+                <tr>
+                  <td>jobId</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>logUploadRegexp</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>maxHealthFailures</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>healthCheckCmd</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>snapshotPolicy</td>
+                  <td><a href="#messages.ContainerInfo.SnapshotPolicy">ContainerInfo.SnapshotPolicy</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>entrypointCmd</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>deprecated: Use process instead </p></td>
+                </tr>
+              
+                <tr>
+                  <td>entrypointStr</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>deprecated: Use process instead </p></td>
+                </tr>
+              
+                <tr>
+                  <td>appName</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>jobGroupStack</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>jobGroupDetail</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>iamProfile</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>networkConfigInfo</td>
+                  <td><a href="#messages.ContainerInfo.NetworkConfigInfo">ContainerInfo.NetworkConfigInfo</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>jobGroupSequence</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>numGpus</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td>optional</td>
+                  <td><p>TODO(Sargun): Remove, and use the Mesos resource info instead </p></td>
+                </tr>
+              
+                <tr>
+                  <td>efsConfigInfo</td>
+                  <td><a href="#messages.ContainerInfo.EfsConfigInfo">ContainerInfo.EfsConfigInfo</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>capabilities</td>
+                  <td><a href="#messages.ContainerInfo.Capabilities">ContainerInfo.Capabilities</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>metatronCreds</td>
+                  <td><a href="#messages.ContainerInfo.MetatronCreds">ContainerInfo.MetatronCreds</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>userProvidedEnv</td>
+                  <td><a href="#messages.ContainerInfo.UserProvidedEnvEntry">ContainerInfo.UserProvidedEnvEntry</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>titusProvidedEnv</td>
+                  <td><a href="#messages.ContainerInfo.TitusProvidedEnvEntry">ContainerInfo.TitusProvidedEnvEntry</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>imageDigest</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>imageDigest has precedence over version </p></td>
+                </tr>
+              
+                <tr>
+                  <td>allowNetworkBursting</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>killWaitSeconds</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td>optional</td>
+                  <td><p>Number of seconds to wait before killing the container
+otherwise, it will use the dockerd default </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ignoreLaunchGuard</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td>optional</td>
+                  <td><p>If the engine that is using this agent supports the
+killinitiated state, this should be set to true.
+That way, when this container is killed, as well as
+when it is launched, the launchguard will be ignored. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>allowNestedContainers</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td>optional</td>
+                  <td><p>Should we allow this container to run privileged enough
+to run internal container runtimes? </p></td>
+                </tr>
+              
+                <tr>
+                  <td>fullyQualifiedImage</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>The image name with the registry </p></td>
+                </tr>
+              
+                <tr>
+                  <td>allowCpuBursting</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td>optional</td>
+                  <td><p>Should this container be allowed to excceed its CPU cap? </p></td>
+                </tr>
+              
+                <tr>
+                  <td>batch</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td>optional</td>
+                  <td><p>Should this be tagged sched_batch? Does it prefer bigger chunks
+of CPU, less frequently? </p></td>
+                </tr>
+              
+                <tr>
+                  <td>s3LogLocations</td>
+                  <td><a href="#messages.ContainerInfo.S3LogLocation">ContainerInfo.S3LogLocation</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>oomScoreAdj</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td>optional</td>
+                  <td><p>This influences the value of oom_score_adj for the PID 1 (tini) of the container
+
+The value of /proc/&lt;pid&gt;/oom_score_adj is added to the badness score before it
+is used to determine which task to kill.  Acceptable values range from -1000
+(OOM_SCORE_ADJ_MIN) to &#43;1000 (OOM_SCORE_ADJ_MAX).  This allows userspace to
+polarize the preference for oom killing either by always preferring a certain
+task or completely disabling it.  The lowest possible value, -1000, is
+equivalent to disabling oom killing entirely for that task since it will always
+report a badness score of 0.
+
+If this value is unset, it will be set to &#43;1000 as default. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>imagePullPolicy</td>
+                  <td><a href="#messages.ContainerInfo.ImagePullPolicy">ContainerInfo.ImagePullPolicy</a></td>
+                  <td>optional</td>
+                  <td><p>If omitted, Always is the default </p></td>
+                </tr>
+              
+                <tr>
+                  <td>passthroughAttributes</td>
+                  <td><a href="#messages.ContainerInfo.PassthroughAttributesEntry">ContainerInfo.PassthroughAttributesEntry</a></td>
+                  <td>repeated</td>
+                  <td><p>passthrough attributes are an arbitrary set of key / value pairs that are passed from API to executor </p></td>
+                </tr>
+              
+                <tr>
+                  <td>process</td>
+                  <td><a href="#messages.ContainerInfo.Process">ContainerInfo.Process</a></td>
+                  <td>optional</td>
+                  <td><p>Process to be executed inside the container </p></td>
+                </tr>
+              
+                <tr>
+                  <td>runState</td>
+                  <td><a href="#messages.RunningContainerInfo">RunningContainerInfo</a></td>
+                  <td>optional</td>
+                  <td><p>Used internally by the agent to store information about a running container </p></td>
+                </tr>
+              
+                <tr>
+                  <td>shmSizeMB</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td>optional</td>
+                  <td><p>(Optional) Amount of shared memory to allocate (must be &lt;= memoryMB) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signedAddressAllocation</td>
+                  <td><a href="#com.netflix.titus.SignedAddressAllocation">com.netflix.titus.SignedAddressAllocation</a></td>
+                  <td>optional</td>
+                  <td><p>(Optional) IP address allocation for the task </p></td>
+                </tr>
+              
+                <tr>
+                  <td>jobAcceptedTimestampMs</td>
+                  <td><a href="#uint64">uint64</a></td>
+                  <td>optional</td>
+                  <td><p>Timestamp in epoch millis of when the task&#39;s job was Accepted </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+            
+            
+            <h4>Fields with deprecated option</h4>
+            <table>
+              <thead>
+                <tr>
+                  <td>Name</td>
+                  <td>Option</td>
+                </tr>
+              </thead>
+              <tbody>
+              
+                <tr>
+                  <td>containerPorts</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+                <tr>
+                  <td>environmentVariable</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+                <tr>
+                  <td>maxHealthFailures</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+                <tr>
+                  <td>healthCheckCmd</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+                <tr>
+                  <td>snapshotPolicy</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+                <tr>
+                  <td>entrypointCmd</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+                <tr>
+                  <td>entrypointStr</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+              </tbody>
+            </table>
+            
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.Capabilities">ContainerInfo.Capabilities</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>add</td>
+                  <td><a href="#messages.ContainerInfo.Capabilities.Capability">ContainerInfo.Capabilities.Capability</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>drop</td>
+                  <td><a href="#messages.ContainerInfo.Capabilities.Capability">ContainerInfo.Capabilities.Capability</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.EfsConfigInfo">ContainerInfo.EfsConfigInfo</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>efsFsId</td>
+                  <td><a href="#string">string</a></td>
+                  <td>required</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>mountPoint</td>
+                  <td><a href="#string">string</a></td>
+                  <td>required</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>mntPerms</td>
+                  <td><a href="#messages.ContainerInfo.EfsConfigInfo.MountPerms">ContainerInfo.EfsConfigInfo.MountPerms</a></td>
+                  <td>optional</td>
+                  <td><p>Defaults to first enum value </p></td>
+                </tr>
+              
+                <tr>
+                  <td>efsFsRelativeMntPoint</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.EnvironmentVariable">ContainerInfo.EnvironmentVariable</h3>
+        <p>deprecated: use userProvidedEnv and titusProvidedEnv instead</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.MetatronCreds">ContainerInfo.MetatronCreds</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>appMetadata</td>
+                  <td><a href="#string">string</a></td>
+                  <td>required</td>
+                  <td><p>An encoded description of the task&#39;s job metadata </p></td>
+                </tr>
+              
+                <tr>
+                  <td>metadataSig</td>
+                  <td><a href="#string">string</a></td>
+                  <td>required</td>
+                  <td><p>An encoded description of the metadata signature </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.NetworkConfigInfo">ContainerInfo.NetworkConfigInfo</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>eniLablel</td>
+                  <td><a href="#string">string</a></td>
+                  <td>required</td>
+                  <td><p>deprecated: use eniLabel instead </p></td>
+                </tr>
+              
+                <tr>
+                  <td>eniLabel</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>this should be required, but it was added later (typo fix) and is optional for backwards compatibility </p></td>
+                </tr>
+              
+                <tr>
+                  <td>securityGroups</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>bandwidthLimitMbps</td>
+                  <td><a href="#uint32">uint32</a></td>
+                  <td>optional</td>
+                  <td><p>In Mbps </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+            
+            
+            <h4>Fields with deprecated option</h4>
+            <table>
+              <thead>
+                <tr>
+                  <td>Name</td>
+                  <td>Option</td>
+                </tr>
+              </thead>
+              <tbody>
+              
+                <tr>
+                  <td>eniLablel</td>
+                  <td><p>true</p></td>
+                </tr>
+              
+              </tbody>
+            </table>
+            
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.PassthroughAttributesEntry">ContainerInfo.PassthroughAttributesEntry</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>key</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.Process">ContainerInfo.Process</h3>
+        <p>entrypoint and command follow Docker semantics, and can be used to override what is baked into the Docker image:</p><p>https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact</p><p>Both CMD and ENTRYPOINT baked into the image can be explicitly cleared with a single empty value (i.e.: `[""]`).</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>entrypoint</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>when set, will override ENTRYPOINT baked into the image, and cause CMD from the image to be ignored </p></td>
+                </tr>
+              
+                <tr>
+                  <td>command</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>when set, will override CMD baked into the image </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.S3LogLocation">ContainerInfo.S3LogLocation</h3>
+        <p>The s3 log location used when uploading logs</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>bucket</td>
+                  <td><a href="#string">string</a></td>
+                  <td>required</td>
+                  <td><p>The bucket to use for all uploads </p></td>
+                </tr>
+              
+                <tr>
+                  <td>prefix</td>
+                  <td><a href="#string">string</a></td>
+                  <td>required</td>
+                  <td><p>The prefix to use for all object keys. e.g. foo/bar </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.TitusProvidedEnvEntry">ContainerInfo.TitusProvidedEnvEntry</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>key</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.ContainerInfo.UserProvidedEnvEntry">ContainerInfo.UserProvidedEnvEntry</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>key</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.RunningContainerInfo">RunningContainerInfo</h3>
+        <p>Agent-only structure: stores container info for a currently running container</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>hostName</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>Container hostname (not necessarily the same as task ID) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>taskId</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>Container task ID </p></td>
+                </tr>
+              
+                <tr>
+                  <td>launchTimeUnixSec</td>
+                  <td><a href="#uint64">uint64</a></td>
+                  <td>optional</td>
+                  <td><p>Container launch timestamp, in Unix epoch seconds </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.StateUpdate">StateUpdate</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>id</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>state</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>message</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>timestamp</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.StateUpdates">StateUpdates</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>stateUpdate</td>
+                  <td><a href="#messages.StateUpdate">StateUpdate</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskIdentity">TaskIdentity</h3>
+        <p>For the identity client to query the metadata server to confirm the</p><p>currently running task's identity</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>task</td>
+                  <td><a href="#messages.TaskInfo">TaskInfo</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Current state of the task </p></td>
+                </tr>
+              
+                <tr>
+                  <td>container</td>
+                  <td><a href="#messages.ContainerInfo">ContainerInfo</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Container details, including:
+ - app name, stack, detail
+ - image name, digest, label
+ - environment variables
+ - command, entrypoint
+ - metadata string and signature from caller </p></td>
+                </tr>
+              
+                <tr>
+                  <td>unixTimestampSec</td>
+                  <td><a href="#uint64">uint64</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Timestamp, in Unix epoch seconds, when request was made. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ipv4Address</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) IP address of container </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ipv6Address</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>(Optional) IPv6 address of container </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskIdentityDocument">TaskIdentityDocument</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>identity</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Serialized form of a TaskIdentity protobuf. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#messages.CertificateSignature">CertificateSignature</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Signature produced by signing identity bytes. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskIdentityStringDocument">TaskIdentityStringDocument</h3>
+        <p>Version of TaskIdentityDocument that encodes all byte[]s as human-readable strings</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>identity</td>
+                  <td><a href="#messages.TaskIdentity">TaskIdentity</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Task Identity </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#messages.CertificateStringSignature">CertificateStringSignature</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Signature produced by signing identity bytes. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskInfo">TaskInfo</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>containerId</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>taskId</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>hostName</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>slaveId</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#messages.TaskInfo.Status">TaskInfo.Status</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>message</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>environmentVariable</td>
+                  <td><a href="#messages.TaskInfo.EnvironmentVariable">TaskInfo.EnvironmentVariable</a></td>
+                  <td>repeated</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskInfo.EnvironmentVariable">TaskInfo.EnvironmentVariable</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskPodIdentity">TaskPodIdentity</h3>
+        <p>For the identity client to query the metadata server to confirm the</p><p>currently running task's identity based on the whole pod</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>taskInfo</td>
+                  <td><a href="#messages.TaskInfo">TaskInfo</a></td>
+                  <td>required</td>
+                  <td><p>(Required) Current state of the task </p></td>
+                </tr>
+              
+                <tr>
+                  <td>pod</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>required</td>
+                  <td><p>(Required) Pod details in bytes!
+&gt; For the same reason, we do not recommend embedding these proto objects within your own proto definitions.
+&gt; It is better to store Kubernetes objects as byte arrays, in the wire format, which is self-describing.
+&gt; This permits you to use either JSON or binary (proto) wire formats without code changes.
+&gt; It will be difficult for you to operate on both Custom Resources and built-in types otherwise. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>requestTimestamp</td>
+                  <td><a href="#google.protobuf.Timestamp">google.protobuf.Timestamp</a></td>
+                  <td>required</td>
+                  <td><p>(Required) Timestamp, in Unix epoch seconds, when request was made. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ipv4Address</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>(Optional) IP address of container </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ipv6Address</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>(Optional) IPv6 address of container </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskPodIdentityDocument">TaskPodIdentityDocument</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>podIdentity</td>
+                  <td><a href="#bytes">bytes</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Serialized form of a TaskIdentity protobuf. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>signature</td>
+                  <td><a href="#messages.CertificateSignature">CertificateSignature</a></td>
+                  <td>optional</td>
+                  <td><p>(Required) Signature produced by signing identity bytes. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="messages.TaskStatusData">TaskStatusData</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>timestamp</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td>required</td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+        <h3 id="messages.ContainerInfo.Capabilities.Capability">ContainerInfo.Capabilities.Capability</h3>
+        <p>Taken from include/uapi/linux/capability.h</p><p>#define _LINUX_CAPABILITY_VERSION_3  0x20080522</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>CHOWN</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>DAC_OVERRIDE</td>
+                <td>1</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>DAC_READ_SEARCH</td>
+                <td>2</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>FOWNER</td>
+                <td>3</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>FSETID</td>
+                <td>4</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>KILL</td>
+                <td>5</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SETGID</td>
+                <td>6</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SETUID</td>
+                <td>7</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SETPCAP</td>
+                <td>8</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>LINUX_IMMUTABLE</td>
+                <td>9</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>NET_BIND_SERVICE</td>
+                <td>10</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>NET_BROADCAST</td>
+                <td>11</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>NET_ADMIN</td>
+                <td>12</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>NET_RAW</td>
+                <td>13</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>IPC_LOCK</td>
+                <td>14</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>IPC_OWNER</td>
+                <td>15</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_MODULE</td>
+                <td>16</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_RAWIO</td>
+                <td>17</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_CHROOT</td>
+                <td>18</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_PTRACE</td>
+                <td>19</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_PACCT</td>
+                <td>20</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_ADMIN</td>
+                <td>21</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_BOOT</td>
+                <td>22</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_NICE</td>
+                <td>23</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_RESOURCE</td>
+                <td>24</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_TIME</td>
+                <td>25</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYS_TTY_CONFIG</td>
+                <td>26</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>MKNOD</td>
+                <td>27</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>LEASE</td>
+                <td>28</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>AUDIT_WRITE</td>
+                <td>29</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>AUDIT_CONTROL</td>
+                <td>30</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SETFCAP</td>
+                <td>31</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>MAC_OVERRIDE</td>
+                <td>32</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>MAC_ADMIN</td>
+                <td>33</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SYSLOG</td>
+                <td>34</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>WAKE_ALARM</td>
+                <td>35</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>BLOCK_SUSPEND</td>
+                <td>36</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>AUDIT_READ</td>
+                <td>37</td>
+                <td><p></p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="messages.ContainerInfo.EfsConfigInfo.MountPerms">ContainerInfo.EfsConfigInfo.MountPerms</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>RW</td>
+                <td>1</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>RO</td>
+                <td>2</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>WO</td>
+                <td>3</td>
+                <td><p></p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="messages.ContainerInfo.ImagePullPolicy">ContainerInfo.ImagePullPolicy</h3>
+        <p>Borrowed from Kubernetes</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>Always</td>
+                <td>0</td>
+                <td><p>Always pull the tag / digest</p></td>
+              </tr>
+            
+              <tr>
+                <td>IfNotPresent</td>
+                <td>1</td>
+                <td><p>Only pull if we don&#39;t have an image with that given tag / digest (guarantees freshness, as it requires digest)</p></td>
+              </tr>
+            
+              <tr>
+                <td>IfLabelPresent</td>
+                <td>2</td>
+                <td><p>Only pull if we don&#39;t have an image with that given tag</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="messages.ContainerInfo.SnapshotPolicy">ContainerInfo.SnapshotPolicy</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>NEVER</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>ERROR_ONLY</td>
+                <td>1</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SUCCESS_ONLY</td>
+                <td>2</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>ALWAYS</td>
+                <td>3</td>
+                <td><p></p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="messages.SignatureAlgorithm">SignatureAlgorithm</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>SHA256withRSAandMGF1</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SHA384withRSAandMGF1</td>
+                <td>1</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SHA512withRSAandMGF1</td>
+                <td>2</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SHA256withECDSA</td>
+                <td>3</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SHA384withECDSA</td>
+                <td>4</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>SHA512withECDSA</td>
+                <td>5</td>
+                <td><p></p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="messages.TaskInfo.Status">TaskInfo.Status</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>RUNNING</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>FAILED</td>
+                <td>1</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>STOPPED</td>
+                <td>2</td>
+                <td><p></p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+
+      
+
+      
+    
+
+    <h2 id="scalar-value-types">Scalar Value Types</h2>
+    <table class="scalar-value-types-table">
+      <thead>
+        <tr><td>.proto Type</td><td>Notes</td><td>C++</td><td>Java</td><td>Python</td><td>Go</td><td>C#</td><td>PHP</td><td>Ruby</td></tr>
+      </thead>
+      <tbody>
+        
+          <tr id="double">
+            <td>double</td>
+            <td></td>
+            <td>double</td>
+            <td>double</td>
+            <td>float</td>
+            <td>float64</td>
+            <td>double</td>
+            <td>float</td>
+            <td>Float</td>
+          </tr>
+        
+          <tr id="float">
+            <td>float</td>
+            <td></td>
+            <td>float</td>
+            <td>float</td>
+            <td>float</td>
+            <td>float32</td>
+            <td>float</td>
+            <td>float</td>
+            <td>Float</td>
+          </tr>
+        
+          <tr id="int32">
+            <td>int32</td>
+            <td>Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead.</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="int64">
+            <td>int64</td>
+            <td>Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead.</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="uint32">
+            <td>uint32</td>
+            <td>Uses variable-length encoding.</td>
+            <td>uint32</td>
+            <td>int</td>
+            <td>int/long</td>
+            <td>uint32</td>
+            <td>uint</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="uint64">
+            <td>uint64</td>
+            <td>Uses variable-length encoding.</td>
+            <td>uint64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>uint64</td>
+            <td>ulong</td>
+            <td>integer/string</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="sint32">
+            <td>sint32</td>
+            <td>Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s.</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="sint64">
+            <td>sint64</td>
+            <td>Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s.</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="fixed32">
+            <td>fixed32</td>
+            <td>Always four bytes. More efficient than uint32 if values are often greater than 2^28.</td>
+            <td>uint32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>uint32</td>
+            <td>uint</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="fixed64">
+            <td>fixed64</td>
+            <td>Always eight bytes. More efficient than uint64 if values are often greater than 2^56.</td>
+            <td>uint64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>uint64</td>
+            <td>ulong</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="sfixed32">
+            <td>sfixed32</td>
+            <td>Always four bytes.</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="sfixed64">
+            <td>sfixed64</td>
+            <td>Always eight bytes.</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="bool">
+            <td>bool</td>
+            <td></td>
+            <td>bool</td>
+            <td>boolean</td>
+            <td>boolean</td>
+            <td>bool</td>
+            <td>bool</td>
+            <td>boolean</td>
+            <td>TrueClass/FalseClass</td>
+          </tr>
+        
+          <tr id="string">
+            <td>string</td>
+            <td>A string must always contain UTF-8 encoded or 7-bit ASCII text.</td>
+            <td>string</td>
+            <td>String</td>
+            <td>str/unicode</td>
+            <td>string</td>
+            <td>string</td>
+            <td>string</td>
+            <td>String (UTF-8)</td>
+          </tr>
+        
+          <tr id="bytes">
+            <td>bytes</td>
+            <td>May contain any arbitrary sequence of bytes.</td>
+            <td>string</td>
+            <td>ByteString</td>
+            <td>str</td>
+            <td>[]byte</td>
+            <td>ByteString</td>
+            <td>string</td>
+            <td>String (ASCII-8BIT)</td>
+          </tr>
+        
+      </tbody>
+    </table>
+  </body>
+</html>
+

--- a/doc/titus-agent-api-spec.md
+++ b/doc/titus-agent-api-spec.md
@@ -1,0 +1,646 @@
+# Protocol Documentation
+<a name="top"></a>
+
+## Table of Contents
+
+- [src/main/proto/netflix/titus/agent.proto](#src/main/proto/netflix/titus/agent.proto)
+    - [CertificateSignature](#messages.CertificateSignature)
+    - [CertificateStringSignature](#messages.CertificateStringSignature)
+    - [ContainerInfo](#messages.ContainerInfo)
+    - [ContainerInfo.Capabilities](#messages.ContainerInfo.Capabilities)
+    - [ContainerInfo.EfsConfigInfo](#messages.ContainerInfo.EfsConfigInfo)
+    - [ContainerInfo.EnvironmentVariable](#messages.ContainerInfo.EnvironmentVariable)
+    - [ContainerInfo.MetatronCreds](#messages.ContainerInfo.MetatronCreds)
+    - [ContainerInfo.NetworkConfigInfo](#messages.ContainerInfo.NetworkConfigInfo)
+    - [ContainerInfo.PassthroughAttributesEntry](#messages.ContainerInfo.PassthroughAttributesEntry)
+    - [ContainerInfo.Process](#messages.ContainerInfo.Process)
+    - [ContainerInfo.S3LogLocation](#messages.ContainerInfo.S3LogLocation)
+    - [ContainerInfo.TitusProvidedEnvEntry](#messages.ContainerInfo.TitusProvidedEnvEntry)
+    - [ContainerInfo.UserProvidedEnvEntry](#messages.ContainerInfo.UserProvidedEnvEntry)
+    - [RunningContainerInfo](#messages.RunningContainerInfo)
+    - [StateUpdate](#messages.StateUpdate)
+    - [StateUpdates](#messages.StateUpdates)
+    - [TaskIdentity](#messages.TaskIdentity)
+    - [TaskIdentityDocument](#messages.TaskIdentityDocument)
+    - [TaskIdentityStringDocument](#messages.TaskIdentityStringDocument)
+    - [TaskInfo](#messages.TaskInfo)
+    - [TaskInfo.EnvironmentVariable](#messages.TaskInfo.EnvironmentVariable)
+    - [TaskPodIdentity](#messages.TaskPodIdentity)
+    - [TaskPodIdentityDocument](#messages.TaskPodIdentityDocument)
+    - [TaskStatusData](#messages.TaskStatusData)
+  
+    - [ContainerInfo.Capabilities.Capability](#messages.ContainerInfo.Capabilities.Capability)
+    - [ContainerInfo.EfsConfigInfo.MountPerms](#messages.ContainerInfo.EfsConfigInfo.MountPerms)
+    - [ContainerInfo.ImagePullPolicy](#messages.ContainerInfo.ImagePullPolicy)
+    - [ContainerInfo.SnapshotPolicy](#messages.ContainerInfo.SnapshotPolicy)
+    - [SignatureAlgorithm](#messages.SignatureAlgorithm)
+    - [TaskInfo.Status](#messages.TaskInfo.Status)
+  
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="src/main/proto/netflix/titus/agent.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## src/main/proto/netflix/titus/agent.proto
+
+
+
+<a name="messages.CertificateSignature"></a>
+
+### CertificateSignature
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| signature | [bytes](#bytes) | optional | (Required) Raw signature produced from signing input bytes using the private key of the titus agent’s certificate. |
+| algorithm | [SignatureAlgorithm](#messages.SignatureAlgorithm) | optional | (Required) Signature algorithm used (e.g. SHA512withRSAandMGF1) |
+| certChain | [bytes](#bytes) | repeated | (Required) The agent’s public certificate in DER form, followed by its trust chain. |
+
+
+
+
+
+
+<a name="messages.CertificateStringSignature"></a>
+
+### CertificateStringSignature
+Version of CertificateSignature that encodes all byte[]s as human-readable strings
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| signature | [string](#string) | optional | (Required) Base64 signature produced from signing input bytes using the private key of the titus agent’s certificate. |
+| algorithm | [SignatureAlgorithm](#messages.SignatureAlgorithm) | optional | (Required) Signature algorithm used (e.g. SHA512withRSAandMGF1) |
+| certChain | [string](#string) | repeated | (Required) The agent’s public certificate in DER form, followed by its trust chain. |
+
+
+
+
+
+
+<a name="messages.ContainerInfo"></a>
+
+### ContainerInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| imageName | [string](#string) | optional |  |
+| command | [string](#string) | optional | deprecated. replaced by entrypointCmd. |
+| containerPorts | [string](#string) | optional |  |
+| version | [string](#string) | optional |  Default: latest |
+| environmentVariable | [ContainerInfo.EnvironmentVariable](#messages.ContainerInfo.EnvironmentVariable) | repeated | deprecated: use userProvidedEnv and titusProvidedEnv instead |
+| jobId | [string](#string) | optional |  |
+| logUploadRegexp | [string](#string) | optional |  |
+| maxHealthFailures | [uint32](#uint32) | optional |  |
+| healthCheckCmd | [string](#string) | repeated |  |
+| snapshotPolicy | [ContainerInfo.SnapshotPolicy](#messages.ContainerInfo.SnapshotPolicy) | optional |  |
+| entrypointCmd | [string](#string) | repeated | deprecated: Use process instead |
+| entrypointStr | [string](#string) | optional | deprecated: Use process instead |
+| appName | [string](#string) | optional |  |
+| jobGroupStack | [string](#string) | optional |  |
+| jobGroupDetail | [string](#string) | optional |  |
+| iamProfile | [string](#string) | optional |  |
+| networkConfigInfo | [ContainerInfo.NetworkConfigInfo](#messages.ContainerInfo.NetworkConfigInfo) | optional |  |
+| jobGroupSequence | [string](#string) | optional |  |
+| numGpus | [uint32](#uint32) | optional | TODO(Sargun): Remove, and use the Mesos resource info instead |
+| efsConfigInfo | [ContainerInfo.EfsConfigInfo](#messages.ContainerInfo.EfsConfigInfo) | repeated |  |
+| capabilities | [ContainerInfo.Capabilities](#messages.ContainerInfo.Capabilities) | optional |  |
+| metatronCreds | [ContainerInfo.MetatronCreds](#messages.ContainerInfo.MetatronCreds) | optional |  |
+| userProvidedEnv | [ContainerInfo.UserProvidedEnvEntry](#messages.ContainerInfo.UserProvidedEnvEntry) | repeated |  |
+| titusProvidedEnv | [ContainerInfo.TitusProvidedEnvEntry](#messages.ContainerInfo.TitusProvidedEnvEntry) | repeated |  |
+| imageDigest | [string](#string) | optional | imageDigest has precedence over version |
+| allowNetworkBursting | [bool](#bool) | optional |  |
+| killWaitSeconds | [uint32](#uint32) | optional | Number of seconds to wait before killing the container otherwise, it will use the dockerd default |
+| ignoreLaunchGuard | [bool](#bool) | optional | If the engine that is using this agent supports the killinitiated state, this should be set to true. That way, when this container is killed, as well as when it is launched, the launchguard will be ignored. |
+| allowNestedContainers | [bool](#bool) | optional | Should we allow this container to run privileged enough to run internal container runtimes? |
+| fullyQualifiedImage | [string](#string) | optional | The image name with the registry |
+| allowCpuBursting | [bool](#bool) | optional | Should this container be allowed to excceed its CPU cap? |
+| batch | [bool](#bool) | optional | Should this be tagged sched_batch? Does it prefer bigger chunks of CPU, less frequently? |
+| s3LogLocations | [ContainerInfo.S3LogLocation](#messages.ContainerInfo.S3LogLocation) | repeated |  |
+| oomScoreAdj | [int32](#int32) | optional | This influences the value of oom_score_adj for the PID 1 (tini) of the container
+
+The value of /proc/&lt;pid&gt;/oom_score_adj is added to the badness score before it is used to determine which task to kill. Acceptable values range from -1000 (OOM_SCORE_ADJ_MIN) to &#43;1000 (OOM_SCORE_ADJ_MAX). This allows userspace to polarize the preference for oom killing either by always preferring a certain task or completely disabling it. The lowest possible value, -1000, is equivalent to disabling oom killing entirely for that task since it will always report a badness score of 0.
+
+If this value is unset, it will be set to &#43;1000 as default. |
+| imagePullPolicy | [ContainerInfo.ImagePullPolicy](#messages.ContainerInfo.ImagePullPolicy) | optional | If omitted, Always is the default |
+| passthroughAttributes | [ContainerInfo.PassthroughAttributesEntry](#messages.ContainerInfo.PassthroughAttributesEntry) | repeated | passthrough attributes are an arbitrary set of key / value pairs that are passed from API to executor |
+| process | [ContainerInfo.Process](#messages.ContainerInfo.Process) | optional | Process to be executed inside the container |
+| runState | [RunningContainerInfo](#messages.RunningContainerInfo) | optional | Used internally by the agent to store information about a running container |
+| shmSizeMB | [uint32](#uint32) | optional | (Optional) Amount of shared memory to allocate (must be &lt;= memoryMB) |
+| signedAddressAllocation | [com.netflix.titus.SignedAddressAllocation](#com.netflix.titus.SignedAddressAllocation) | optional | (Optional) IP address allocation for the task |
+| jobAcceptedTimestampMs | [uint64](#uint64) | optional | Timestamp in epoch millis of when the task&#39;s job was Accepted |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.Capabilities"></a>
+
+### ContainerInfo.Capabilities
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| add | [ContainerInfo.Capabilities.Capability](#messages.ContainerInfo.Capabilities.Capability) | repeated |  |
+| drop | [ContainerInfo.Capabilities.Capability](#messages.ContainerInfo.Capabilities.Capability) | repeated |  |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.EfsConfigInfo"></a>
+
+### ContainerInfo.EfsConfigInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| efsFsId | [string](#string) | required |  |
+| mountPoint | [string](#string) | required |  |
+| mntPerms | [ContainerInfo.EfsConfigInfo.MountPerms](#messages.ContainerInfo.EfsConfigInfo.MountPerms) | optional | Defaults to first enum value |
+| efsFsRelativeMntPoint | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.EnvironmentVariable"></a>
+
+### ContainerInfo.EnvironmentVariable
+deprecated: use userProvidedEnv and titusProvidedEnv instead
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) | optional |  |
+| value | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.MetatronCreds"></a>
+
+### ContainerInfo.MetatronCreds
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| appMetadata | [string](#string) | required | An encoded description of the task&#39;s job metadata |
+| metadataSig | [string](#string) | required | An encoded description of the metadata signature |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.NetworkConfigInfo"></a>
+
+### ContainerInfo.NetworkConfigInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| eniLablel | [string](#string) | required | deprecated: use eniLabel instead |
+| eniLabel | [string](#string) | optional | this should be required, but it was added later (typo fix) and is optional for backwards compatibility |
+| securityGroups | [string](#string) | repeated |  |
+| bandwidthLimitMbps | [uint32](#uint32) | optional | In Mbps |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.PassthroughAttributesEntry"></a>
+
+### ContainerInfo.PassthroughAttributesEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) | optional |  |
+| value | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.Process"></a>
+
+### ContainerInfo.Process
+entrypoint and command follow Docker semantics, and can be used to override what is baked into the Docker image:
+https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+
+Both CMD and ENTRYPOINT baked into the image can be explicitly cleared with a single empty value (i.e.: `[&#34;&#34;]`).
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entrypoint | [string](#string) | repeated | when set, will override ENTRYPOINT baked into the image, and cause CMD from the image to be ignored |
+| command | [string](#string) | repeated | when set, will override CMD baked into the image |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.S3LogLocation"></a>
+
+### ContainerInfo.S3LogLocation
+The s3 log location used when uploading logs
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bucket | [string](#string) | required | The bucket to use for all uploads |
+| prefix | [string](#string) | required | The prefix to use for all object keys. e.g. foo/bar |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.TitusProvidedEnvEntry"></a>
+
+### ContainerInfo.TitusProvidedEnvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) | optional |  |
+| value | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="messages.ContainerInfo.UserProvidedEnvEntry"></a>
+
+### ContainerInfo.UserProvidedEnvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) | optional |  |
+| value | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="messages.RunningContainerInfo"></a>
+
+### RunningContainerInfo
+Agent-only structure: stores container info for a currently running container
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| hostName | [string](#string) | optional | Container hostname (not necessarily the same as task ID) |
+| taskId | [string](#string) | optional | Container task ID |
+| launchTimeUnixSec | [uint64](#uint64) | optional | Container launch timestamp, in Unix epoch seconds |
+
+
+
+
+
+
+<a name="messages.StateUpdate"></a>
+
+### StateUpdate
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) | optional |  |
+| state | [string](#string) | optional |  |
+| message | [string](#string) | optional |  |
+| timestamp | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="messages.StateUpdates"></a>
+
+### StateUpdates
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| stateUpdate | [StateUpdate](#messages.StateUpdate) | repeated |  |
+
+
+
+
+
+
+<a name="messages.TaskIdentity"></a>
+
+### TaskIdentity
+For the identity client to query the metadata server to confirm the
+currently running task&#39;s identity
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| task | [TaskInfo](#messages.TaskInfo) | optional | (Required) Current state of the task |
+| container | [ContainerInfo](#messages.ContainerInfo) | optional | (Required) Container details, including: - app name, stack, detail - image name, digest, label - environment variables - command, entrypoint - metadata string and signature from caller |
+| unixTimestampSec | [uint64](#uint64) | optional | (Required) Timestamp, in Unix epoch seconds, when request was made. |
+| ipv4Address | [string](#string) | optional | (Required) IP address of container |
+| ipv6Address | [string](#string) | optional | (Optional) IPv6 address of container |
+
+
+
+
+
+
+<a name="messages.TaskIdentityDocument"></a>
+
+### TaskIdentityDocument
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| identity | [bytes](#bytes) | optional | (Required) Serialized form of a TaskIdentity protobuf. |
+| signature | [CertificateSignature](#messages.CertificateSignature) | optional | (Required) Signature produced by signing identity bytes. |
+
+
+
+
+
+
+<a name="messages.TaskIdentityStringDocument"></a>
+
+### TaskIdentityStringDocument
+Version of TaskIdentityDocument that encodes all byte[]s as human-readable strings
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| identity | [TaskIdentity](#messages.TaskIdentity) | optional | (Required) Task Identity |
+| signature | [CertificateStringSignature](#messages.CertificateStringSignature) | optional | (Required) Signature produced by signing identity bytes. |
+
+
+
+
+
+
+<a name="messages.TaskInfo"></a>
+
+### TaskInfo
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| containerId | [string](#string) | optional |  |
+| taskId | [string](#string) | optional |  |
+| hostName | [string](#string) | optional |  |
+| slaveId | [string](#string) | optional |  |
+| status | [TaskInfo.Status](#messages.TaskInfo.Status) | optional |  |
+| message | [string](#string) | optional |  |
+| environmentVariable | [TaskInfo.EnvironmentVariable](#messages.TaskInfo.EnvironmentVariable) | repeated |  |
+
+
+
+
+
+
+<a name="messages.TaskInfo.EnvironmentVariable"></a>
+
+### TaskInfo.EnvironmentVariable
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) | optional |  |
+| value | [string](#string) | optional |  |
+
+
+
+
+
+
+<a name="messages.TaskPodIdentity"></a>
+
+### TaskPodIdentity
+For the identity client to query the metadata server to confirm the
+currently running task&#39;s identity based on the whole pod
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| taskInfo | [TaskInfo](#messages.TaskInfo) | required | (Required) Current state of the task |
+| pod | [bytes](#bytes) | required | (Required) Pod details in bytes! &gt; For the same reason, we do not recommend embedding these proto objects within your own proto definitions. &gt; It is better to store Kubernetes objects as byte arrays, in the wire format, which is self-describing. &gt; This permits you to use either JSON or binary (proto) wire formats without code changes. &gt; It will be difficult for you to operate on both Custom Resources and built-in types otherwise. |
+| requestTimestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) | required | (Required) Timestamp, in Unix epoch seconds, when request was made. |
+| ipv4Address | [string](#string) | optional | (Optional) IP address of container |
+| ipv6Address | [string](#string) | optional | (Optional) IPv6 address of container |
+
+
+
+
+
+
+<a name="messages.TaskPodIdentityDocument"></a>
+
+### TaskPodIdentityDocument
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| podIdentity | [bytes](#bytes) | optional | (Required) Serialized form of a TaskIdentity protobuf. |
+| signature | [CertificateSignature](#messages.CertificateSignature) | optional | (Required) Signature produced by signing identity bytes. |
+
+
+
+
+
+
+<a name="messages.TaskStatusData"></a>
+
+### TaskStatusData
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| timestamp | [int64](#int64) | required |  |
+
+
+
+
+
+ 
+
+
+<a name="messages.ContainerInfo.Capabilities.Capability"></a>
+
+### ContainerInfo.Capabilities.Capability
+Taken from include/uapi/linux/capability.h
+#define _LINUX_CAPABILITY_VERSION_3  0x20080522
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CHOWN | 0 |  |
+| DAC_OVERRIDE | 1 |  |
+| DAC_READ_SEARCH | 2 |  |
+| FOWNER | 3 |  |
+| FSETID | 4 |  |
+| KILL | 5 |  |
+| SETGID | 6 |  |
+| SETUID | 7 |  |
+| SETPCAP | 8 |  |
+| LINUX_IMMUTABLE | 9 |  |
+| NET_BIND_SERVICE | 10 |  |
+| NET_BROADCAST | 11 |  |
+| NET_ADMIN | 12 |  |
+| NET_RAW | 13 |  |
+| IPC_LOCK | 14 |  |
+| IPC_OWNER | 15 |  |
+| SYS_MODULE | 16 |  |
+| SYS_RAWIO | 17 |  |
+| SYS_CHROOT | 18 |  |
+| SYS_PTRACE | 19 |  |
+| SYS_PACCT | 20 |  |
+| SYS_ADMIN | 21 |  |
+| SYS_BOOT | 22 |  |
+| SYS_NICE | 23 |  |
+| SYS_RESOURCE | 24 |  |
+| SYS_TIME | 25 |  |
+| SYS_TTY_CONFIG | 26 |  |
+| MKNOD | 27 |  |
+| LEASE | 28 |  |
+| AUDIT_WRITE | 29 |  |
+| AUDIT_CONTROL | 30 |  |
+| SETFCAP | 31 |  |
+| MAC_OVERRIDE | 32 |  |
+| MAC_ADMIN | 33 |  |
+| SYSLOG | 34 |  |
+| WAKE_ALARM | 35 |  |
+| BLOCK_SUSPEND | 36 |  |
+| AUDIT_READ | 37 |  |
+
+
+
+<a name="messages.ContainerInfo.EfsConfigInfo.MountPerms"></a>
+
+### ContainerInfo.EfsConfigInfo.MountPerms
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| RW | 1 |  |
+| RO | 2 |  |
+| WO | 3 |  |
+
+
+
+<a name="messages.ContainerInfo.ImagePullPolicy"></a>
+
+### ContainerInfo.ImagePullPolicy
+Borrowed from Kubernetes
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| Always | 0 | Always pull the tag / digest |
+| IfNotPresent | 1 | Only pull if we don&#39;t have an image with that given tag / digest (guarantees freshness, as it requires digest) |
+| IfLabelPresent | 2 | Only pull if we don&#39;t have an image with that given tag |
+
+
+
+<a name="messages.ContainerInfo.SnapshotPolicy"></a>
+
+### ContainerInfo.SnapshotPolicy
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| NEVER | 0 |  |
+| ERROR_ONLY | 1 |  |
+| SUCCESS_ONLY | 2 |  |
+| ALWAYS | 3 |  |
+
+
+
+<a name="messages.SignatureAlgorithm"></a>
+
+### SignatureAlgorithm
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| SHA256withRSAandMGF1 | 0 |  |
+| SHA384withRSAandMGF1 | 1 |  |
+| SHA512withRSAandMGF1 | 2 |  |
+| SHA256withECDSA | 3 |  |
+| SHA384withECDSA | 4 |  |
+| SHA512withECDSA | 5 |  |
+
+
+
+<a name="messages.TaskInfo.Status"></a>
+
+### TaskInfo.Status
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| RUNNING | 0 |  |
+| FAILED | 1 |  |
+| STOPPED | 2 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
+

--- a/src/main/proto/netflix/titus/agent.proto
+++ b/src/main/proto/netflix/titus/agent.proto
@@ -3,6 +3,7 @@ syntax = "proto2";
 package messages;
 
 import "netflix/titus/titus_base.proto";
+import "google/protobuf/timestamp.proto";
 
 option java_package = "io.titanframework.messages";
 option java_outer_classname = "TitanProtos";
@@ -321,6 +322,29 @@ message TaskIdentity {
     optional string ipv6Address = 5;
 }
 
+// For the identity client to query the metadata server to confirm the
+// currently running task's identity based on the whole pod
+message TaskPodIdentity {
+    // (Required) Current state of the task 
+    required messages.TaskInfo taskInfo = 1;
+
+    // (Required) Pod details in bytes!
+    // > For the same reason, we do not recommend embedding these proto objects within your own proto definitions.
+    // > It is better to store Kubernetes objects as byte arrays, in the wire format, which is self-describing.
+    // > This permits you to use either JSON or binary (proto) wire formats without code changes.
+    // > It will be difficult for you to operate on both Custom Resources and built-in types otherwise.
+    required bytes pod = 2;
+
+    // (Required) Timestamp, in Unix epoch seconds, when request was made.
+    required google.protobuf.Timestamp requestTimestamp = 3;
+
+    // (Optional) IP address of container
+    optional string ipv4Address = 4;
+
+    // (Optional) IPv6 address of container
+    optional string ipv6Address = 5;
+}
+
 enum SignatureAlgorithm {
     SHA256withRSAandMGF1 = 0;
     SHA384withRSAandMGF1 = 1;
@@ -370,4 +394,12 @@ message TaskIdentityStringDocument {
 
     // (Required) Signature produced by signing identity bytes.
     optional CertificateStringSignature signature = 2;
+}
+
+message TaskPodIdentityDocument {
+    // (Required) Serialized form of a TaskIdentity protobuf.
+    optional bytes podIdentity = 1;
+
+    // (Required) Signature produced by signing identity bytes.
+    optional CertificateSignature signature = 2;
 }


### PR DESCRIPTION
This is a new type of identity document for metatron
to use that will be "pod-aware".

This is a pretty big departure from what we used to do,
which was to provide a very titus'y document.

With this change, we just give away the whole pod and
expect the consumer to know how to understand it,
*and* to verify the pod "looks" correct based on what
it is expected.

I'm not 100% sure about the whole embedding of the pod
in terms of bytes there. The docs say we could either
just put the whole json in there or binary proto stuff,
but I do like the idea of not changing the api definitions
as the pod spec evolves. This puts a bit more burden on
the consumer, because they need to decode the pod themselves.


---- 

I'm still very much a proto noob here. 