### PR TITLE
Added support for requesting platform sidecars on jobs

### DIFF
--- a/doc/titus-v3-spec.html
+++ b/doc/titus-v3-spec.html
@@ -407,6 +407,14 @@
                 </li>
               
                 <li>
+                  <a href="#com.netflix.titus.PlatformSidecar"><span class="badge">M</span>PlatformSidecar</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.PlatformSidecar.ArgumentsEntry"><span class="badge">M</span>PlatformSidecar.ArgumentsEntry</a>
+                </li>
+              
+                <li>
                   <a href="#com.netflix.titus.SecurityProfile"><span class="badge">M</span>SecurityProfile</a>
                 </li>
               
@@ -1598,7 +1606,21 @@ provided by the backend. </p></td>
                   <td><p>(Optional) Extra Containers can be specificed to run alongside the main
 container in a &#34;pod&#34; (similar to k8s pods). Additional containers
 can be specified in this field, and they will be launched together with
-the main container, sharing its resources (network/ram/cpu/gpu/etc). </p></td>
+the main container, sharing its resources (network/ram/cpu/gpu/etc).
+Startup ordering happens in the following way:
+1. Titus System Services
+2. Platform Sidecars (configured below)
+3A. extraContiners (this field)
+3B. The main container (`container` field) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>platformSidecars</td>
+                  <td><a href="#com.netflix.titus.PlatformSidecar">PlatformSidecar</a></td>
+                  <td>repeated</td>
+                  <td><p>(Optional) Array of platform sidecars to launch alongside the task.
+These platform sidecars are always ordered *after* Titus System Services,
+and *before* any user container (main or extraContainers). </p></td>
                 </tr>
               
             </tbody>
@@ -2623,6 +2645,75 @@ only jobs with tasks that require migration </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>(Required) An owner&#39;s email address. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.PlatformSidecar">PlatformSidecar</h3>
+        <p>Definition of a request to add a platform sidecar alongside a task</p><p>Note that this is *not* a user-defined sidecar, that is why it just has a</p><p>name. These platform-sidecars are attached a task start time, and the</p><p>definition of what the sidecar is is not baked into the job itself, just the</p><p>intent.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>(Required) Name of the platform sidecar requested </p></td>
+                </tr>
+              
+                <tr>
+                  <td>channel</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>(Optional) Channel representing a pointer to releases of the sidecar </p></td>
+                </tr>
+              
+                <tr>
+                  <td>arguments</td>
+                  <td><a href="#com.netflix.titus.PlatformSidecar.ArgumentsEntry">PlatformSidecar.ArgumentsEntry</a></td>
+                  <td>repeated</td>
+                  <td><p>(Optional) Arguments, KV pairs for configuring the sidecar </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.PlatformSidecar.ArgumentsEntry">PlatformSidecar.ArgumentsEntry</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>key</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
                 </tr>
               
             </tbody>

--- a/doc/titus-v3-spec.md
+++ b/doc/titus-v3-spec.md
@@ -61,6 +61,8 @@
     - [ObserveJobsQuery](#com.netflix.titus.ObserveJobsQuery)
     - [ObserveJobsQuery.FilteringCriteriaEntry](#com.netflix.titus.ObserveJobsQuery.FilteringCriteriaEntry)
     - [Owner](#com.netflix.titus.Owner)
+    - [PlatformSidecar](#com.netflix.titus.PlatformSidecar)
+    - [PlatformSidecar.ArgumentsEntry](#com.netflix.titus.PlatformSidecar.ArgumentsEntry)
     - [SecurityProfile](#com.netflix.titus.SecurityProfile)
     - [SecurityProfile.AttributesEntry](#com.netflix.titus.SecurityProfile.AttributesEntry)
     - [ServiceJobSpec](#com.netflix.titus.ServiceJobSpec)
@@ -556,7 +558,8 @@ is used to run a job.
 | service | [ServiceJobSpec](#com.netflix.titus.ServiceJobSpec) |  | Service job specific descriptor. |
 | disruptionBudget | [JobDisruptionBudget](#com.netflix.titus.JobDisruptionBudget) |  | (Optional) Job disruption budget. If not defined, a job type specific (batch or service) default is set. |
 | networkConfiguration | [NetworkConfiguration](#com.netflix.titus.NetworkConfiguration) |  | (Optional) Networking configuration. If not defined, sane defaults are provided by the backend. |
-| extraContainers | [BasicContainer](#com.netflix.titus.BasicContainer) | repeated | (Optional) Extra Containers can be specificed to run alongside the main container in a &#34;pod&#34; (similar to k8s pods). Additional containers can be specified in this field, and they will be launched together with the main container, sharing its resources (network/ram/cpu/gpu/etc). |
+| extraContainers | [BasicContainer](#com.netflix.titus.BasicContainer) | repeated | (Optional) Extra Containers can be specificed to run alongside the main container in a &#34;pod&#34; (similar to k8s pods). Additional containers can be specified in this field, and they will be launched together with the main container, sharing its resources (network/ram/cpu/gpu/etc). Startup ordering happens in the following way: 1. Titus System Services 2. Platform Sidecars (configured below) 3A. extraContiners (this field) 3B. The main container (`container` field) |
+| platformSidecars | [PlatformSidecar](#com.netflix.titus.PlatformSidecar) | repeated | (Optional) Array of platform sidecars to launch alongside the task. These platform sidecars are always ordered *after* Titus System Services, and *before* any user container (main or extraContainers). |
 
 
 
@@ -1096,6 +1099,43 @@ An owner of a job.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | teamEmail | [string](#string) |  | (Required) An owner&#39;s email address. |
+
+
+
+
+
+
+<a name="com.netflix.titus.PlatformSidecar"></a>
+
+### PlatformSidecar
+Definition of a request to add a platform sidecar alongside a task
+Note that this is *not* a user-defined sidecar, that is why it just has a
+name. These platform-sidecars are attached a task start time, and the
+definition of what the sidecar is is not baked into the job itself, just the
+intent.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | (Required) Name of the platform sidecar requested |
+| channel | [string](#string) |  | (Optional) Channel representing a pointer to releases of the sidecar |
+| arguments | [PlatformSidecar.ArgumentsEntry](#com.netflix.titus.PlatformSidecar.ArgumentsEntry) | repeated | (Optional) Arguments, KV pairs for configuring the sidecar |
+
+
+
+
+
+
+<a name="com.netflix.titus.PlatformSidecar.ArgumentsEntry"></a>
+
+### PlatformSidecar.ArgumentsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
 
 
 

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -7,6 +7,7 @@ package com.netflix.titus;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 import "netflix/titus/titus_base.proto";
 
@@ -81,6 +82,22 @@ message Image {
 
   // (Required if tag not set) Image digest.
   string digest = 3;
+}
+
+// Definition of a request to add a platform sidecar alongside a task
+// Note that this is *not* a user-defined sidecar, that is why it just has a
+// name. These platform-sidecars are attached a task start time, and the
+// definition of what the sidecar is is not baked into the job itself, just the
+// intent.
+message PlatformSidecar {
+  // (Required) Name of the platform sidecar requested
+  string name = 1;
+
+  // (Optional) Channel representing a pointer to releases of the sidecar
+  string channel = 2;
+
+  // (Optional) Arguments, KV pairs for configuring the sidecar
+  google.protobuf.Struct arguments = 3;
 }
 
 // Network settings for tasks launched by this job
@@ -579,6 +596,11 @@ message JobDescriptor {
   // container in a "pod" (similar to k8s pods). Additional containers
   // can be specified in this field, and they will be launched together with
   // the main container, sharing its resources (network/ram/cpu/gpu/etc).
+  // Startup ordering happens in the following way:
+  // 1. Titus System Services
+  // 2. Platform Sidecars (configured below)
+  // 3A. extraContiners (this field)
+  // 3B. The main container (`container` field)
   repeated BasicContainer extraContainers = 12;
 
   // (Optional) An array of Volumes to be used by one or more of the
@@ -587,6 +609,11 @@ message JobDescriptor {
   // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core
   // Note that Titus only supports a subset of storage drivers.
   repeated Volume volumes = 13;
+
+  // (Optional) Array of platform sidecars to launch alongside the task.
+  // These platform sidecars are always ordered *after* Titus System Services,
+  // and *before* any user container (main or extraContainers).
+  repeated PlatformSidecar platformSidecars = 14;
 }
 
 // Composite data structure holding both job state information and the reason


### PR DESCRIPTION
This is v0 of the platform sidecar stuff.

It includes the bare minimum that we will need (the name)
for including a platform sidecar.

I kinda hope this is all we will need! API stuff is a bit expensive,
and if we can get away with just saying "I want gandalf" then that would be
great.

"sidecar packs" are out of scope here of course, they come from a higher
level orchistrator. (newt may create your spin pipeline requesting
gandalf, metatron, shrimpi, etc for you)

This may feel a tad early, but because it takes so long for API requests
to get to the point where they are usable, I wanted to get a head start.