### PR TITLE
Added support for specifying extraContainers in a job

### DIFF
--- a/doc/titus-v3-spec.html
+++ b/doc/titus-v3-spec.html
@@ -179,6 +179,14 @@
             <ul>
               
                 <li>
+                  <a href="#com.netflix.titus.BasicContainer"><span class="badge">M</span>BasicContainer</a>
+                </li>
+              
+                <li>
+                  <a href="#com.netflix.titus.BasicContainer.EnvEntry"><span class="badge">M</span>BasicContainer.EnvEntry</a>
+                </li>
+              
+                <li>
                   <a href="#com.netflix.titus.BatchJobSpec"><span class="badge">M</span>BatchJobSpec</a>
                 </li>
               
@@ -516,6 +524,97 @@
       <p></p>
 
       
+        <h3 id="com.netflix.titus.BasicContainer">BasicContainer</h3>
+        <p>BasicContainer stores the minimal data required to declare extra containers</p><p>to a job. This is in contrast to the Container message, which has other data</p><p>that are not strictly tied to the main container. For example,</p><p>*resources* (ram/cpu/etc) for the whole *task* are declared in the main</p><p>Container message, not in a basic container.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>(Required) the Name of this container </p></td>
+                </tr>
+              
+                <tr>
+                  <td>image</td>
+                  <td><a href="#com.netflix.titus.Image">Image</a></td>
+                  <td></td>
+                  <td><p>(Required) Image reference. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>entryPoint</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>(Optional) Override the entrypoint of the image.
+If set, the command baked into the image (if any) is always ignored.
+Interactions between the entrypoint and command are the same as specified
+by Docker:
+https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+Note that, unlike the main container, no string splitting occurs. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>command</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>(Optional) Additional parameters for the entrypoint defined either here
+or provided in the container image.
+Note that, unlike the main container, no string splitting occurs. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>env</td>
+                  <td><a href="#com.netflix.titus.BasicContainer.EnvEntry">BasicContainer.EnvEntry</a></td>
+                  <td>repeated</td>
+                  <td><p>(Optional) A collection of system environment variables passed to the
+container. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="com.netflix.titus.BasicContainer.EnvEntry">BasicContainer.EnvEntry</h3>
+        <p></p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>key</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>value</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="com.netflix.titus.BatchJobSpec">BatchJobSpec</h3>
         <p>Batch job specification.</p>
 
@@ -683,7 +782,7 @@ given, all must be met (logical &#39;and&#39;). </p></td>
                   <td>resources</td>
                   <td><a href="#com.netflix.titus.ContainerResources">ContainerResources</a></td>
                   <td></td>
-                  <td><p>(Required) Container resources. </p></td>
+                  <td><p>(Required) Resources for the whole task. </p></td>
                 </tr>
               
                 <tr>
@@ -713,13 +812,13 @@ container roles. </p></td>
                   <td>entryPoint</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>(Optional) Override the entry point of the image.
+                  <td><p>(Optional) Override the entrypoint of the image.
 If set, the command baked into the image (if any) is always ignored.
-Interactions between the entry point and command are the same as specified
+Interactions between the entrypoint and command are the same as specified
 by Docker:
 https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
 
- To clear (unset) the entry point of the image, pass a single empty string
+ To clear (unset) the entrypoint of the image, pass a single empty string
  value: [&#34;&#34;] </p></td>
                 </tr>
               
@@ -727,7 +826,7 @@ https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypo
                   <td>command</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>(Optional) Additional parameters for the entry point defined either here
+                  <td><p>(Optional) Additional parameters for the entrypoint defined either here
 or provided in the container image.
 To clear (unset) the command of the image, pass a single empty string
 value: [&#34;&#34;] </p></td>
@@ -746,7 +845,7 @@ container. </p></td>
                   <td><a href="#com.netflix.titus.Constraints">Constraints</a></td>
                   <td></td>
                   <td><p>(Optional) Constraints that Titus will prefer to fulfill but are not
-required. </p></td>
+required. These constraints apply to the whole task. </p></td>
                 </tr>
               
                 <tr>
@@ -754,7 +853,7 @@ required. </p></td>
                   <td><a href="#com.netflix.titus.Constraints">Constraints</a></td>
                   <td></td>
                   <td><p>(Optional) Constraints that have to be met for a task to be scheduled on
-an agent. </p></td>
+an agent. These constraints apply to the whole task. </p></td>
                 </tr>
               
                 <tr>
@@ -847,39 +946,39 @@ an agent. </p></td>
                   <td>cpu</td>
                   <td><a href="#double">double</a></td>
                   <td></td>
-                  <td><p>(Required) Number of CPUs to allocate (must be always &gt; 0, but the actual
-limit is configurable). </p></td>
+                  <td><p>(Required) Number of CPUs to allocate to a task
+(must be always &gt; 0, but the actual limit is configurable). </p></td>
                 </tr>
               
                 <tr>
                   <td>gpu</td>
                   <td><a href="#uint32">uint32</a></td>
                   <td></td>
-                  <td><p>(Optional) Number of GPUs to allocate. </p></td>
+                  <td><p>(Optional) Number of GPUs to allocate to a task. </p></td>
                 </tr>
               
                 <tr>
                   <td>memoryMB</td>
                   <td><a href="#uint32">uint32</a></td>
                   <td></td>
-                  <td><p>(Required) Amount of memory to allocate (must be always &gt; 0, but the
-actual limit is configurable). </p></td>
+                  <td><p>(Required) Amount of memory to allocate to a task
+(must be always &gt; 0, but the actual limit is configurable). </p></td>
                 </tr>
               
                 <tr>
                   <td>diskMB</td>
                   <td><a href="#uint32">uint32</a></td>
                   <td></td>
-                  <td><p>(Required) Amount of disk space to allocate (must be always &gt; 0, but the
-actual limit is configurable). </p></td>
+                  <td><p>(Required) Amount of ephemeral disk space to allocate to a task
+(must be always &gt; 0, but the actual limit is configurable). </p></td>
                 </tr>
               
                 <tr>
                   <td>networkMbps</td>
                   <td><a href="#uint32">uint32</a></td>
                   <td></td>
-                  <td><p>(Required) Amount of network bandwidth to allocate (must be always &gt; 0,
-but the actual limit is configurable). </p></td>
+                  <td><p>(Required) Amount of network bandwidth to allocate to an individual task
+(must be always &gt; 0, but the actual limit is configurable). </p></td>
                 </tr>
               
                 <tr>
@@ -1490,6 +1589,16 @@ own unique identifier for a job (see JobGroupInfo for more information). </p></t
                   <td></td>
                   <td><p>(Optional) Networking configuration. If not defined, sane defaults are
 provided by the backend. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>extraContainers</td>
+                  <td><a href="#com.netflix.titus.BasicContainer">BasicContainer</a></td>
+                  <td>repeated</td>
+                  <td><p>(Optional) Extra Containers can be specificed to run alongside the main
+container in a &#34;pod&#34; (similar to k8s pods). Additional containers
+can be specified in this field, and they will be launched together with
+the main container, sharing its resources (network/ram/cpu/gpu/etc). </p></td>
                 </tr>
               
             </tbody>

--- a/doc/titus-v3-spec.md
+++ b/doc/titus-v3-spec.md
@@ -4,6 +4,8 @@
 ## Table of Contents
 
 - [src/main/proto/netflix/titus/titus_job_api.proto](#src/main/proto/netflix/titus/titus_job_api.proto)
+    - [BasicContainer](#com.netflix.titus.BasicContainer)
+    - [BasicContainer.EnvEntry](#com.netflix.titus.BasicContainer.EnvEntry)
     - [BatchJobSpec](#com.netflix.titus.BatchJobSpec)
     - [Capacity](#com.netflix.titus.Capacity)
     - [Constraints](#com.netflix.titus.Constraints)
@@ -98,6 +100,45 @@
 
 
 
+<a name="com.netflix.titus.BasicContainer"></a>
+
+### BasicContainer
+BasicContainer stores the minimal data required to declare extra containers
+to a job. This is in contrast to the Container message, which has other data
+that are not strictly tied to the main container. For example,
+*resources* (ram/cpu/etc) for the whole *task* are declared in the main
+Container message, not in a basic container.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | (Required) the Name of this container |
+| image | [Image](#com.netflix.titus.Image) |  | (Required) Image reference. |
+| entryPoint | [string](#string) | repeated | (Optional) Override the entrypoint of the image. If set, the command baked into the image (if any) is always ignored. Interactions between the entrypoint and command are the same as specified by Docker: https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact Note that, unlike the main container, no string splitting occurs. |
+| command | [string](#string) | repeated | (Optional) Additional parameters for the entrypoint defined either here or provided in the container image. Note that, unlike the main container, no string splitting occurs. |
+| env | [BasicContainer.EnvEntry](#com.netflix.titus.BasicContainer.EnvEntry) | repeated | (Optional) A collection of system environment variables passed to the container. |
+
+
+
+
+
+
+<a name="com.netflix.titus.BasicContainer.EnvEntry"></a>
+
+### BasicContainer.EnvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+
 <a name="com.netflix.titus.BatchJobSpec"></a>
 
 ### BatchJobSpec
@@ -182,17 +223,17 @@ Container descriptor.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| resources | [ContainerResources](#com.netflix.titus.ContainerResources) |  | (Required) Container resources. |
+| resources | [ContainerResources](#com.netflix.titus.ContainerResources) |  | (Required) Resources for the whole task. |
 | securityProfile | [SecurityProfile](#com.netflix.titus.SecurityProfile) |  | (Required) Container security profile: IAM role, security groups, container roles. |
 | image | [Image](#com.netflix.titus.Image) |  | (Required) Image reference. |
 | attributes | [Container.AttributesEntry](#com.netflix.titus.Container.AttributesEntry) | repeated | (Optional) Arbitrary set of key/value pairs. Key names starting with &#39;titus.&#39; are reserved by Titus. |
-| entryPoint | [string](#string) | repeated | (Optional) Override the entry point of the image. If set, the command baked into the image (if any) is always ignored. Interactions between the entry point and command are the same as specified by Docker: https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+| entryPoint | [string](#string) | repeated | (Optional) Override the entrypoint of the image. If set, the command baked into the image (if any) is always ignored. Interactions between the entrypoint and command are the same as specified by Docker: https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
 
- To clear (unset) the entry point of the image, pass a single empty string value: [&#34;&#34;] |
-| command | [string](#string) | repeated | (Optional) Additional parameters for the entry point defined either here or provided in the container image. To clear (unset) the command of the image, pass a single empty string value: [&#34;&#34;] |
+ To clear (unset) the entrypoint of the image, pass a single empty string value: [&#34;&#34;] |
+| command | [string](#string) | repeated | (Optional) Additional parameters for the entrypoint defined either here or provided in the container image. To clear (unset) the command of the image, pass a single empty string value: [&#34;&#34;] |
 | env | [Container.EnvEntry](#com.netflix.titus.Container.EnvEntry) | repeated | (Optional) A collection of system environment variables passed to the container. |
-| softConstraints | [Constraints](#com.netflix.titus.Constraints) |  | (Optional) Constraints that Titus will prefer to fulfill but are not required. |
-| hardConstraints | [Constraints](#com.netflix.titus.Constraints) |  | (Optional) Constraints that have to be met for a task to be scheduled on an agent. |
+| softConstraints | [Constraints](#com.netflix.titus.Constraints) |  | (Optional) Constraints that Titus will prefer to fulfill but are not required. These constraints apply to the whole task. |
+| hardConstraints | [Constraints](#com.netflix.titus.Constraints) |  | (Optional) Constraints that have to be met for a task to be scheduled on an agent. These constraints apply to the whole task. |
 | experimental | [google.protobuf.Any](#google.protobuf.Any) |  | (Optional) Experimental features |
 
 
@@ -240,11 +281,11 @@ Container descriptor.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| cpu | [double](#double) |  | (Required) Number of CPUs to allocate (must be always &gt; 0, but the actual limit is configurable). |
-| gpu | [uint32](#uint32) |  | (Optional) Number of GPUs to allocate. |
-| memoryMB | [uint32](#uint32) |  | (Required) Amount of memory to allocate (must be always &gt; 0, but the actual limit is configurable). |
-| diskMB | [uint32](#uint32) |  | (Required) Amount of disk space to allocate (must be always &gt; 0, but the actual limit is configurable). |
-| networkMbps | [uint32](#uint32) |  | (Required) Amount of network bandwidth to allocate (must be always &gt; 0, but the actual limit is configurable). |
+| cpu | [double](#double) |  | (Required) Number of CPUs to allocate to a task (must be always &gt; 0, but the actual limit is configurable). |
+| gpu | [uint32](#uint32) |  | (Optional) Number of GPUs to allocate to a task. |
+| memoryMB | [uint32](#uint32) |  | (Required) Amount of memory to allocate to a task (must be always &gt; 0, but the actual limit is configurable). |
+| diskMB | [uint32](#uint32) |  | (Required) Amount of ephemeral disk space to allocate to a task (must be always &gt; 0, but the actual limit is configurable). |
+| networkMbps | [uint32](#uint32) |  | (Required) Amount of network bandwidth to allocate to an individual task (must be always &gt; 0, but the actual limit is configurable). |
 | allocateIP | [bool](#bool) |  | (Deprecated) IP always allocated. |
 | efsMounts | [ContainerResources.EfsMount](#com.netflix.titus.ContainerResources.EfsMount) | repeated | (Optional) EFS mounts. |
 | shmSizeMB | [uint32](#uint32) |  | (Optional) Size of shared memory /dev/shm. If not set, a default value will be provided. A provided value must be less than or equal to amount of memory allocated. |
@@ -515,6 +556,7 @@ is used to run a job.
 | service | [ServiceJobSpec](#com.netflix.titus.ServiceJobSpec) |  | Service job specific descriptor. |
 | disruptionBudget | [JobDisruptionBudget](#com.netflix.titus.JobDisruptionBudget) |  | (Optional) Job disruption budget. If not defined, a job type specific (batch or service) default is set. |
 | networkConfiguration | [NetworkConfiguration](#com.netflix.titus.NetworkConfiguration) |  | (Optional) Networking configuration. If not defined, sane defaults are provided by the backend. |
+| extraContainers | [BasicContainer](#com.netflix.titus.BasicContainer) | repeated | (Optional) Extra Containers can be specificed to run alongside the main container in a &#34;pod&#34; (similar to k8s pods). Additional containers can be specified in this field, and they will be launched together with the main container, sharing its resources (network/ram/cpu/gpu/etc). |
 
 
 

--- a/src/main/proto/netflix/managedbatch/job.proto
+++ b/src/main/proto/netflix/managedbatch/job.proto
@@ -371,10 +371,10 @@ message Container {
   // (Required) Container image.
   Image image = 3;
 
-  // (Optional) Override the entry point of the image.
+  // (Optional) Override the entrypoint of the image.
   repeated string entryPoint = 4;
 
-  // (Optional) Additional parameters for the entry point defined either here
+  // (Optional) Additional parameters for the entrypoint defined either here
   // or provided in the container image.
   repeated string command = 6;
 

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -109,23 +109,23 @@ message NetworkConfiguration {
 }
 
 message ContainerResources {
-  // (Required) Number of CPUs to allocate (must be always > 0, but the actual
-  // limit is configurable).
+  // (Required) Number of CPUs to allocate to a task
+  // (must be always > 0, but the actual limit is configurable).
   double cpu = 1;
 
-  // (Optional) Number of GPUs to allocate.
+  // (Optional) Number of GPUs to allocate to a task.
   uint32 gpu = 2;
 
-  // (Required) Amount of memory to allocate (must be always > 0, but the
-  // actual limit is configurable).
+  // (Required) Amount of memory to allocate to a task
+  // (must be always > 0, but the actual limit is configurable).
   uint32 memoryMB = 3;
 
-  // (Required) Amount of disk space to allocate (must be always > 0, but the
-  // actual limit is configurable).
+  // (Required) Amount of ephemeral disk space to allocate to a task
+  // (must be always > 0, but the actual limit is configurable).
   uint32 diskMB = 4;
 
-  // (Required) Amount of network bandwidth to allocate (must be always > 0,
-  // but the actual limit is configurable).
+  // (Required) Amount of network bandwidth to allocate to an individual task
+  // (must be always > 0, but the actual limit is configurable).
   uint32 networkMbps = 5;
 
   // (Deprecated) IP always allocated.
@@ -184,7 +184,7 @@ message SecurityProfile {
 
 // Container descriptor.
 message Container {
-  // (Required) Container resources.
+  // (Required) Resources for the whole task.
   ContainerResources resources = 1;
 
   // (Required) Container security profile: IAM role, security groups,
@@ -198,17 +198,17 @@ message Container {
   // 'titus.' are reserved by Titus.
   map<string, string> attributes = 4;
 
-  // (Optional) Override the entry point of the image.
+  // (Optional) Override the entrypoint of the image.
   // If set, the command baked into the image (if any) is always ignored.
-  // Interactions between the entry point and command are the same as specified
+  // Interactions between the entrypoint and command are the same as specified
   // by Docker:
   // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
   //
-  //  To clear (unset) the entry point of the image, pass a single empty string
+  //  To clear (unset) the entrypoint of the image, pass a single empty string
   //  value: [""]
   repeated string entryPoint = 5;
 
-  // (Optional) Additional parameters for the entry point defined either here
+  // (Optional) Additional parameters for the entrypoint defined either here
   // or provided in the container image.
   // To clear (unset) the command of the image, pass a single empty string
   // value: [""]
@@ -219,15 +219,45 @@ message Container {
   map<string, string> env = 7;
 
   // (Optional) Constraints that Titus will prefer to fulfill but are not
-  // required.
+  // required. These constraints apply to the whole task.
   Constraints softConstraints = 8;
 
   // (Optional) Constraints that have to be met for a task to be scheduled on
-  // an agent.
+  // an agent. These constraints apply to the whole task.
   Constraints hardConstraints = 9;
 
   // (Optional) Experimental features
   google.protobuf.Any experimental = 10;
+}
+
+// BasicContainer stores the minimal data required to declare extra containers
+// to a job. This is in contrast to the Container message, which has other data
+// that are not strictly tied to the main container. For example,
+// *resources* (ram/cpu/etc) for the whole *task* are declared in the main
+// Container message, not in a basic container.
+message BasicContainer {
+  // (Required) the Name of this container
+  string name = 1;
+
+  // (Required) Image reference.
+  Image image = 2;
+
+  // (Optional) Override the entrypoint of the image.
+  // If set, the command baked into the image (if any) is always ignored.
+  // Interactions between the entrypoint and command are the same as specified
+  // by Docker:
+  // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+  // Note that, unlike the main container, no string splitting occurs.
+  repeated string entryPoint = 3;
+
+  // (Optional) Additional parameters for the entrypoint defined either here
+  // or provided in the container image.
+  // Note that, unlike the main container, no string splitting occurs.
+  repeated string command = 4;
+
+  // (Optional) A collection of system environment variables passed to the
+  // container.
+  map<string, string> env = 5;
 }
 
 // This data structure is associated with a service job and specifies the
@@ -472,6 +502,12 @@ message JobDescriptor {
   // (Optional) Networking configuration. If not defined, sane defaults are
   // provided by the backend.
   NetworkConfiguration networkConfiguration = 11;
+
+  // (Optional) Extra Containers can be specificed to run alongside the main
+  // container in a "pod" (similar to k8s pods). Additional containers
+  // can be specified in this field, and they will be launched together with
+  // the main container, sharing its resources (network/ram/cpu/gpu/etc).
+  repeated BasicContainer extraContainers = 12;
 }
 
 // Composite data structure holding both job state information and the reason

--- a/src/main/proto/netflix/titus/v4/task_management_api.proto
+++ b/src/main/proto/netflix/titus/v4/task_management_api.proto
@@ -331,10 +331,10 @@ message TaskDescriptor {
 
   string allocationId = 1;
 
-  // (Optional) Override the entry point of the image.
+  // (Optional) Override the entrypoint of the image.
   repeated string entryPoint = 2;
 
-  // (Optional) Additional parameters for the entry point defined either here
+  // (Optional) Additional parameters for the entrypoint defined either here
   // or provided in the container image.
   repeated string command = 3;
 


### PR DESCRIPTION
We finally made it! We are ready to allow users to define
multiple containers in a Job.

In order to keep backwards compatibility, I left the 'main' container
message as-is. This simplifies a lot of stuff for us and our integrators.
The main container will still carry weight for things like the task's
resources, security stuff, attributes, and constraints.

At the same time, I want this feature as not-confusing as possible.
By calling it "extraContainers", it makes it more clear that one does
not need to duplicate the main container definition twice in the job
definition. These really are extra, and the main container stays.

This is not a complete representation of a container. It still needs room
for things like volumes, healthchecks, restart policies, etc. These
will be added in subsequent PRs.