### PR TITLE
RFC: Generate openapi (swagger) files from proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ bin/
 
 # publishing secrets
 secrets/signing-key
+
+# OpenAPI generation stuff
+src/main/proto/google/
+openapi.yaml

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,31 @@ titus-v3-doc:
 		-otitus.protobin --include_imports --include_source_info \
 		src/main/proto/netflix/titus/agent.proto
 
+# Requires this plugin:
+# https://github.com/google/gnostic/tree/master/apps/protoc-gen-openapi
+# TODO: Automate the installation of this with a Make target
+#
+.PHONY: titus-v3-swagger
+titus-v3-swagger:
+	@echo "Generating openapi files for Titus v3 API.."
+	protoc -I/usr/local/include -I. \
+		-Isrc/main/proto \
+		--openapi_out=. \
+		-otitus.pb --include_imports --include_source_info \
+		src/main/proto/netflix/titus/titus_job_api.proto
+	mv openapi.yaml src/main/swagger/netflix/titus-v3/titus-job-api.yaml
+	protoc -I/usr/local/include -I. \
+		-Isrc/main/proto \
+		--openapi_out=. \
+		-otitus.pb --include_imports --include_source_info \
+		src/main/proto/netflix/titus/titus_vpc_api.proto
+	mv openapi.yaml src/main/swagger/netflix/titus-v3/titus-vpc-api.yaml
+	protoc -I/usr/local/include -I. \
+		-Isrc/main/proto \
+		--openapi_out=. \
+		-otitus.pb --include_imports --include_source_info \
+		src/main/proto/netflix/titus/agent.proto
+	mv openapi.yaml src/main/swagger/netflix/titus-v3/titus-agent-api.yaml
+
+# TODO: vendor this better instead of gitignore maybe
+#src/main/proto/google:

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -9,6 +9,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "netflix/titus/titus_base.proto";
+import "google/api/annotations.proto";
 
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
@@ -1083,7 +1084,12 @@ service JobManagementService {
   rpc ObserveJobs(ObserveJobsQuery) returns (stream JobChangeNotification) {}
 
   // Terminate all running tasks of a job, and than terminate the job.
-  rpc KillJob(JobId) returns (google.protobuf.Empty) {}
+  rpc KillJob(JobId) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete : "/api/v3/jobs/{jobId}"
+      body : "*"
+    };
+  }
 
   // Update the attributes of a job. This will either create new attributes or
   // replace existing ones with the same key.

--- a/src/main/swagger/netflix/titus-v3/titus-agent-api.yaml
+++ b/src/main/swagger/netflix/titus-v3/titus-agent-api.yaml
@@ -1,0 +1,10 @@
+# Generated with protoc-gen-openapi
+# https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: ""
+    version: 0.0.1
+paths: {}
+components:
+    schemas: {}

--- a/src/main/swagger/netflix/titus-v3/titus-job-api.yaml
+++ b/src/main/swagger/netflix/titus-v3/titus-job-api.yaml
@@ -1,0 +1,28 @@
+# Generated with protoc-gen-openapi
+# https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: JobManagementService
+    version: 0.0.1
+paths:
+    /api/v3/jobs/{jobId}:
+        delete:
+            summary: Terminate all running tasks of a job, and than terminate the job.
+            operationId: JobManagementService_KillJob
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/JobId'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+components:
+    schemas:
+        JobId:
+            properties:
+                id:
+                    type: string

--- a/src/main/swagger/netflix/titus-v3/titus-vpc-api.yaml
+++ b/src/main/swagger/netflix/titus-v3/titus-vpc-api.yaml
@@ -1,0 +1,10 @@
+# Generated with protoc-gen-openapi
+# https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: TitusAgentVPCInformationService
+    version: 0.0.1
+paths: {}
+components:
+    schemas: {}


### PR DESCRIPTION
It would be cool to bring back OpenAPI. I was wondering if there
was some programmatic way to go back and forth. Seems that there
is, kinda.

This uses this project:
https://grpc-ecosystem.github.io/grpc-gateway/

Which requires one to sprinkle in route annotations into the proto file.

Here is an example:
https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/internal/proto/examplepb/echo_service.proto#L56

In this PR I only added in the Terminate Jobs route + DELETE, but of course
we can add more over time.