### PR TITLE
Extracted shared Titus features to titus_base to be shared more easily

### DIFF
--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -8,7 +8,6 @@ option java_outer_classname = "TitusBase";
 
 option go_package = "./netflix/titus";
 import "google/protobuf/struct.proto";
-import "netflix/titus/titus_volumes.proto";
 
 // ----------------------------------------------------------------------------
 // Supplementary data structures
@@ -374,62 +373,6 @@ message Version {
   // jobs and their tasks will have a single revision counter which is
   // incremented if some job or task entity is created/updated.
   // uint64 revision = 2;
-}
-
-// BasicContainer stores the minimal data required to declare extra containers
-// to a job. This is in contrast to the Container message, which has other data
-// that are not strictly tied to the main container. For example,
-// *resources* (ram/cpu/etc) for the whole *task* are declared in the main
-// Container message, not in a basic container.
-message BasicContainer {
-  // (Required) the Name of this container
-  string name = 1;
-
-  // (Required) Image reference.
-  Image image = 2;
-
-  // (Optional) Override the entrypoint of the image.
-  // If set, the command baked into the image (if any) is always ignored.
-  // Interactions between the entrypoint and command are the same as specified
-  // by Docker:
-  // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
-  // Note that, unlike the main container, no string splitting occurs.
-  repeated string entryPoint = 3;
-
-  // (Optional) Additional parameters for the entrypoint defined either here
-  // or provided in the container image.
-  // Note that, unlike the main container, no string splitting occurs.
-  repeated string command = 4;
-
-  // (Optional) A collection of system environment variables passed to the
-  // container.
-  map<string, string> env = 5;
-
-  // (Optional) An array of VolumeMounts. These VolumeMounts will be mounted in
-  // the container, and must reference one of the volumes declared for the Job.
-  // See the k8s docs
-  // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
-  // for more technical details.
-  repeated VolumeMount volumeMounts = 6;
-}
-
-// To reference an image, a user has to provide an image name and a version. A
-// user may specify a version either with
-// a tag value (for example 'latest') or a digest. When submitting a job, a user
-// should provide either a tag or a digest value only (not both of them).
-//
-// For example, docker images can be referenced by {name=titus-examples,
-// tag=latest}. A user could also choose to provide only the digest without a
-// tag. In this case, the tag value would be empty.
-message Image {
-  // (Required) Image name.
-  string name = 1;
-
-  // (Required if digest not set) Image tag.
-  string tag = 2;
-
-  // (Required if tag not set) Image digest.
-  string digest = 3;
 }
 
 // Definition of a request to add a platform sidecar alongside a task

--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -7,7 +7,6 @@ option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "TitusBase";
 
 option go_package = "./netflix/titus";
-import "google/protobuf/struct.proto";
 
 // ----------------------------------------------------------------------------
 // Supplementary data structures
@@ -373,20 +372,4 @@ message Version {
   // jobs and their tasks will have a single revision counter which is
   // incremented if some job or task entity is created/updated.
   // uint64 revision = 2;
-}
-
-// Definition of a request to add a platform sidecar alongside a task
-// Note that this is *not* a user-defined sidecar, that is why it just has a
-// name. These platform-sidecars are attached a task start time, and the
-// definition of what the sidecar is is not baked into the job itself, just the
-// intent.
-message PlatformSidecar {
-  // (Required) Name of the platform sidecar requested
-  string name = 1;
-
-  // (Optional) Channel representing a pointer to releases of the sidecar
-  string channel = 2;
-
-  // (Optional) Arguments, KV pairs for configuring the sidecar
-  google.protobuf.Struct arguments = 3;
 }

--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "TitusBase";
 
 option go_package = "./netflix/titus";
 import "google/protobuf/struct.proto";
+import "netflix/titus/titus_volumes.proto";
 
 // ----------------------------------------------------------------------------
 // Supplementary data structures
@@ -375,24 +376,6 @@ message Version {
   // uint64 revision = 2;
 }
 
-message SharedContainerVolumeSource {
-  // The sourceContainer is the name of the container with the
-  // path to be shared with other containers. For example:
-  //
-  //     sourceContainer="main"
-  //     sourcePath="/mnt/data"
-  //
-  // combined with an associated VolumeMount on another container, would
-  // be one way to allow the main container to share some of its files
-  // (which may be just baked into the image, or provided by another storage
-  // system) with some other extraContainer for the task.
-  string sourceContainer = 1;
-  // The path in the container to be shared.
-  // This path may contain existing data to share, or it can simply
-  // not exist, and it will be created.
-  string sourcePath = 2;
-}
-
 // BasicContainer stores the minimal data required to declare extra containers
 // to a job. This is in contrast to the Container message, which has other data
 // that are not strictly tied to the main container. For example,
@@ -428,63 +411,6 @@ message BasicContainer {
   // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
   // for more technical details.
   repeated VolumeMount volumeMounts = 6;
-}
-
-// Volumes define some sort of storage for a Task (pod) that is later referenced
-// by individual containers via VolumeMount declarations.
-// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core
-// Note that Titus only supports a subset of storage drivers.
-message Volume {
-  // (Required) the name of the volume. This is what is referenced by
-  // VolumeMount requests for individual containers.
-  string name = 1;
-
-  oneof VolumeSource {
-    // (Optional) A SharedContainerVolumeSource is a volume that exists on the
-    // one container that is exported. Such a volume can be used later via a
-    // VolumeMount and shared with other containers in the task (pod)
-    SharedContainerVolumeSource sharedContainerVolumeSource = 2;
-  }
-}
-
-// VolumeMounts are used to define how to mount a Volume in a container
-// Modeled after k8s volumeMounts:
-// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
-message VolumeMount {
-  // (Required) mountPath is the location inside the container where the volume
-  // will be mounted
-  string mountPath = 1;
-
-  enum MountPropagation {
-    // MountPropagationNone is the default and means that additional mounts
-    // inside a volumeMount will *not* be propagated.
-    MountPropagationNone = 0;
-
-    // MountPropagationHostToContainer specifies that mounts get propagated
-    // from the source mount to the destination ("rslave" in Linux).
-    MountPropagationHostToContainer = 1;
-
-    // MountPropagationBidirectional specifies that mounts get propagated from
-    // the and from the source container to the destination
-    // ("rshared" in Linux).
-    MountPropagationBidirectional = 2;
-  }
-
-  // mountPropagation determines how mounts are propagated from the host to
-  // container and the other way around. When not set, MountPropagationNone is
-  // used.
-  MountPropagation mountPropagation = 2;
-
-  // This must match the Name of a Volume.
-  string volumeName = 3;
-
-  // Mounted read-only if true, read-write otherwise (false or unspecified).
-  // Defaults to false.
-  bool readOnly = 4;
-
-  // Path within the volume from which the container's volume should be mounted.
-  // Defaults to "" (volume's root).
-  string subPath = 5;
 }
 
 // To reference an image, a user has to provide an image name and a version. A

--- a/src/main/proto/netflix/titus/titus_base.proto
+++ b/src/main/proto/netflix/titus/titus_base.proto
@@ -7,6 +7,7 @@ option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "TitusBase";
 
 option go_package = "./netflix/titus";
+import "google/protobuf/struct.proto";
 
 // ----------------------------------------------------------------------------
 // Supplementary data structures
@@ -372,4 +373,151 @@ message Version {
   // jobs and their tasks will have a single revision counter which is
   // incremented if some job or task entity is created/updated.
   // uint64 revision = 2;
+}
+
+message SharedContainerVolumeSource {
+  // The sourceContainer is the name of the container with the
+  // path to be shared with other containers. For example:
+  //
+  //     sourceContainer="main"
+  //     sourcePath="/mnt/data"
+  //
+  // combined with an associated VolumeMount on another container, would
+  // be one way to allow the main container to share some of its files
+  // (which may be just baked into the image, or provided by another storage
+  // system) with some other extraContainer for the task.
+  string sourceContainer = 1;
+  // The path in the container to be shared.
+  // This path may contain existing data to share, or it can simply
+  // not exist, and it will be created.
+  string sourcePath = 2;
+}
+
+// BasicContainer stores the minimal data required to declare extra containers
+// to a job. This is in contrast to the Container message, which has other data
+// that are not strictly tied to the main container. For example,
+// *resources* (ram/cpu/etc) for the whole *task* are declared in the main
+// Container message, not in a basic container.
+message BasicContainer {
+  // (Required) the Name of this container
+  string name = 1;
+
+  // (Required) Image reference.
+  Image image = 2;
+
+  // (Optional) Override the entrypoint of the image.
+  // If set, the command baked into the image (if any) is always ignored.
+  // Interactions between the entrypoint and command are the same as specified
+  // by Docker:
+  // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+  // Note that, unlike the main container, no string splitting occurs.
+  repeated string entryPoint = 3;
+
+  // (Optional) Additional parameters for the entrypoint defined either here
+  // or provided in the container image.
+  // Note that, unlike the main container, no string splitting occurs.
+  repeated string command = 4;
+
+  // (Optional) A collection of system environment variables passed to the
+  // container.
+  map<string, string> env = 5;
+
+  // (Optional) An array of VolumeMounts. These VolumeMounts will be mounted in
+  // the container, and must reference one of the volumes declared for the Job.
+  // See the k8s docs
+  // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
+  // for more technical details.
+  repeated VolumeMount volumeMounts = 6;
+}
+
+// Volumes define some sort of storage for a Task (pod) that is later referenced
+// by individual containers via VolumeMount declarations.
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core
+// Note that Titus only supports a subset of storage drivers.
+message Volume {
+  // (Required) the name of the volume. This is what is referenced by
+  // VolumeMount requests for individual containers.
+  string name = 1;
+
+  oneof VolumeSource {
+    // (Optional) A SharedContainerVolumeSource is a volume that exists on the
+    // one container that is exported. Such a volume can be used later via a
+    // VolumeMount and shared with other containers in the task (pod)
+    SharedContainerVolumeSource sharedContainerVolumeSource = 2;
+  }
+}
+
+// VolumeMounts are used to define how to mount a Volume in a container
+// Modeled after k8s volumeMounts:
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
+message VolumeMount {
+  // (Required) mountPath is the location inside the container where the volume
+  // will be mounted
+  string mountPath = 1;
+
+  enum MountPropagation {
+    // MountPropagationNone is the default and means that additional mounts
+    // inside a volumeMount will *not* be propagated.
+    MountPropagationNone = 0;
+
+    // MountPropagationHostToContainer specifies that mounts get propagated
+    // from the source mount to the destination ("rslave" in Linux).
+    MountPropagationHostToContainer = 1;
+
+    // MountPropagationBidirectional specifies that mounts get propagated from
+    // the and from the source container to the destination
+    // ("rshared" in Linux).
+    MountPropagationBidirectional = 2;
+  }
+
+  // mountPropagation determines how mounts are propagated from the host to
+  // container and the other way around. When not set, MountPropagationNone is
+  // used.
+  MountPropagation mountPropagation = 2;
+
+  // This must match the Name of a Volume.
+  string volumeName = 3;
+
+  // Mounted read-only if true, read-write otherwise (false or unspecified).
+  // Defaults to false.
+  bool readOnly = 4;
+
+  // Path within the volume from which the container's volume should be mounted.
+  // Defaults to "" (volume's root).
+  string subPath = 5;
+}
+
+// To reference an image, a user has to provide an image name and a version. A
+// user may specify a version either with
+// a tag value (for example 'latest') or a digest. When submitting a job, a user
+// should provide either a tag or a digest value only (not both of them).
+//
+// For example, docker images can be referenced by {name=titus-examples,
+// tag=latest}. A user could also choose to provide only the digest without a
+// tag. In this case, the tag value would be empty.
+message Image {
+  // (Required) Image name.
+  string name = 1;
+
+  // (Required if digest not set) Image tag.
+  string tag = 2;
+
+  // (Required if tag not set) Image digest.
+  string digest = 3;
+}
+
+// Definition of a request to add a platform sidecar alongside a task
+// Note that this is *not* a user-defined sidecar, that is why it just has a
+// name. These platform-sidecars are attached a task start time, and the
+// definition of what the sidecar is is not baked into the job itself, just the
+// intent.
+message PlatformSidecar {
+  // (Required) Name of the platform sidecar requested
+  string name = 1;
+
+  // (Optional) Channel representing a pointer to releases of the sidecar
+  string channel = 2;
+
+  // (Optional) Arguments, KV pairs for configuring the sidecar
+  google.protobuf.Struct arguments = 3;
 }

--- a/src/main/proto/netflix/titus/titus_containers.proto
+++ b/src/main/proto/netflix/titus/titus_containers.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+package com.netflix.titus;
+
+option java_multiple_files = true;
+option java_package = "com.netflix.titus.grpc.protogen";
+option java_outer_classname = "TitusBase";
+
+option go_package = "./netflix/titus";
+import "netflix/titus/titus_volumes.proto";
+
+// BasicContainer stores the minimal data required to declare extra containers
+// to a job. This is in contrast to the Container message, which has other data
+// that are not strictly tied to the main container. For example,
+// *resources* (ram/cpu/etc) for the whole *task* are declared in the main
+// Container message, not in a basic container.
+message BasicContainer {
+  // (Required) the Name of this container
+  string name = 1;
+
+  // (Required) Image reference.
+  BasicImage image = 2;
+
+  // (Optional) Override the entrypoint of the image.
+  // If set, the command baked into the image (if any) is always ignored.
+  // Interactions between the entrypoint and command are the same as specified
+  // by Docker:
+  // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+  // Note that, unlike the main container, no string splitting occurs.
+  repeated string entryPoint = 3;
+
+  // (Optional) Additional parameters for the entrypoint defined either here
+  // or provided in the container image.
+  // Note that, unlike the main container, no string splitting occurs.
+  repeated string command = 4;
+
+  // (Optional) A collection of system environment variables passed to the
+  // container.
+  map<string, string> env = 5;
+
+  // (Optional) An array of VolumeMounts. These VolumeMounts will be mounted in
+  // the container, and must reference one of the volumes declared for the Job.
+  // See the k8s docs
+  // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
+  // for more technical details.
+  repeated VolumeMount volumeMounts = 6;
+}
+
+// To reference an image, a user has to provide an image name and a version. A
+// user may specify a version either with
+// a tag value (for example 'latest') or a digest. When submitting a job, a user
+// should provide either a tag or a digest value only (not both of them).
+//
+// For example, docker images can be referenced by {name=titus-examples,
+// tag=latest}. A user could also choose to provide only the digest without a
+// tag. In this case, the tag value would be empty.
+message BasicImage {
+  // (Required) Image name.
+  string name = 1;
+
+  // (Required if digest not set) Image tag.
+  string tag = 2;
+
+  // (Required if tag not set) Image digest.
+  string digest = 3;
+}

--- a/src/main/proto/netflix/titus/titus_containers.proto
+++ b/src/main/proto/netflix/titus/titus_containers.proto
@@ -5,8 +5,9 @@ package com.netflix.titus;
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "TitusBase";
-
 option go_package = "./netflix/titus";
+
+import "google/protobuf/struct.proto";
 import "netflix/titus/titus_volumes.proto";
 
 // BasicContainer stores the minimal data required to declare extra containers
@@ -63,4 +64,20 @@ message BasicImage {
 
   // (Required if tag not set) Image digest.
   string digest = 3;
+}
+
+// Definition of a request to add a platform sidecar alongside a task
+// Note that this is *not* a user-defined sidecar, that is why it just has a
+// name. These platform-sidecars are attached to a task start time, and the
+// definition of what the sidecar is is not baked into the job itself, just the
+// intent.
+message PlatformSidecar {
+  // (Required) Name of the platform sidecar requested
+  string name = 1;
+
+  // (Optional) Channel representing a pointer to releases of the sidecar
+  string channel = 2;
+
+  // (Optional) Arguments, KV pairs for configuring the sidecar
+  google.protobuf.Struct arguments = 3;
 }

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -9,6 +9,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "netflix/titus/titus_base.proto";
+import "netflix/titus/titus_volumes.proto";
 
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -10,6 +10,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "netflix/titus/titus_base.proto";
 import "netflix/titus/titus_volumes.proto";
+import "netflix/titus/titus_containers.proto";
 
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
@@ -63,6 +64,25 @@ message Constraints {
   // 'zoneBalance AND serverGroup == "mySG"'. Avalilable operators: <, <=, ==,
   // >, >=, in, like, AND, OR
   string expression = 2;
+}
+
+// To reference an image, a user has to provide an image name and a version. A
+// user may specify a version either with
+// a tag value (for example 'latest') or a digest. When submitting a job, a user
+// should provide either a tag or a digest value only (not both of them).
+//
+// For example, docker images can be referenced by {name=titus-examples,
+// tag=latest}. A user could also choose to provide only the digest without a
+// tag. In this case, the tag value would be empty.
+message Image {
+  // (Required) Image name.
+  string name = 1;
+
+  // (Required if digest not set) Image tag.
+  string tag = 2;
+
+  // (Required if tag not set) Image digest.
+  string digest = 3;
 }
 
 // Network settings for tasks launched by this job

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -7,7 +7,6 @@ package com.netflix.titus;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 import "netflix/titus/titus_base.proto";
 
@@ -63,41 +62,6 @@ message Constraints {
   // 'zoneBalance AND serverGroup == "mySG"'. Avalilable operators: <, <=, ==,
   // >, >=, in, like, AND, OR
   string expression = 2;
-}
-
-// To reference an image, a user has to provide an image name and a version. A
-// user may specify a version either with
-// a tag value (for example 'latest') or a digest. When submitting a job, a user
-// should provide either a tag or a digest value only (not both of them).
-//
-// For example, docker images can be referenced by {name=titus-examples,
-// tag=latest}. A user could also choose to provide only the digest without a
-// tag. In this case, the tag value would be empty.
-message Image {
-  // (Required) Image name.
-  string name = 1;
-
-  // (Required if digest not set) Image tag.
-  string tag = 2;
-
-  // (Required if tag not set) Image digest.
-  string digest = 3;
-}
-
-// Definition of a request to add a platform sidecar alongside a task
-// Note that this is *not* a user-defined sidecar, that is why it just has a
-// name. These platform-sidecars are attached a task start time, and the
-// definition of what the sidecar is is not baked into the job itself, just the
-// intent.
-message PlatformSidecar {
-  // (Required) Name of the platform sidecar requested
-  string name = 1;
-
-  // (Optional) Channel representing a pointer to releases of the sidecar
-  string channel = 2;
-
-  // (Optional) Arguments, KV pairs for configuring the sidecar
-  google.protobuf.Struct arguments = 3;
 }
 
 // Network settings for tasks launched by this job
@@ -252,118 +216,6 @@ message Container {
   // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
   // for more technical details.
   repeated VolumeMount volumeMounts = 11;
-}
-
-// BasicContainer stores the minimal data required to declare extra containers
-// to a job. This is in contrast to the Container message, which has other data
-// that are not strictly tied to the main container. For example,
-// *resources* (ram/cpu/etc) for the whole *task* are declared in the main
-// Container message, not in a basic container.
-message BasicContainer {
-  // (Required) the Name of this container
-  string name = 1;
-
-  // (Required) Image reference.
-  Image image = 2;
-
-  // (Optional) Override the entrypoint of the image.
-  // If set, the command baked into the image (if any) is always ignored.
-  // Interactions between the entrypoint and command are the same as specified
-  // by Docker:
-  // https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
-  // Note that, unlike the main container, no string splitting occurs.
-  repeated string entryPoint = 3;
-
-  // (Optional) Additional parameters for the entrypoint defined either here
-  // or provided in the container image.
-  // Note that, unlike the main container, no string splitting occurs.
-  repeated string command = 4;
-
-  // (Optional) A collection of system environment variables passed to the
-  // container.
-  map<string, string> env = 5;
-
-  // (Optional) An array of VolumeMounts. These VolumeMounts will be mounted in
-  // the container, and must reference one of the volumes declared for the Job.
-  // See the k8s docs
-  // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
-  // for more technical details.
-  repeated VolumeMount volumeMounts = 6;
-}
-
-// Volumes define some sort of storage for a Task (pod) that is later referenced
-// by individual containers via VolumeMount declarations.
-// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core
-// Note that Titus only supports a subset of storage drivers.
-message Volume {
-  // (Required) the name of the volume. This is what is referenced by
-  // VolumeMount requests for individual containers.
-  string name = 1;
-
-  oneof VolumeSource {
-    // (Optional) A SharedContainerVolumeSource is a volume that exists on the
-    // one container that is exported. Such a volume can be used later via a
-    // VolumeMount and shared with other containers in the task (pod)
-    SharedContainerVolumeSource sharedContainerVolumeSource = 2;
-  }
-}
-
-// VolumeMounts are used to define how to mount a Volume in a container
-// Modeled after k8s volumeMounts:
-// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
-message VolumeMount {
-  // (Required) mountPath is the location inside the container where the volume
-  // will be mounted
-  string mountPath = 1;
-
-  enum MountPropagation {
-    // MountPropagationNone is the default and means that additional mounts
-    // inside a volumeMount will *not* be propagated.
-    MountPropagationNone = 0;
-
-    // MountPropagationHostToContainer specifies that mounts get propagated
-    // from the source mount to the destination ("rslave" in Linux).
-    MountPropagationHostToContainer = 1;
-
-    // MountPropagationBidirectional specifies that mounts get propagated from
-    // the and from the source container to the destination
-    // ("rshared" in Linux).
-    MountPropagationBidirectional = 2;
-  }
-
-  // mountPropagation determines how mounts are propagated from the host to
-  // container and the other way around. When not set, MountPropagationNone is
-  // used.
-  MountPropagation mountPropagation = 2;
-
-  // This must match the Name of a Volume.
-  string volumeName = 3;
-
-  // Mounted read-only if true, read-write otherwise (false or unspecified).
-  // Defaults to false.
-  bool readOnly = 4;
-
-  // Path within the volume from which the container's volume should be mounted.
-  // Defaults to "" (volume's root).
-  string subPath = 5;
-}
-
-message SharedContainerVolumeSource {
-  // The sourceContainer is the name of the container with the
-  // path to be shared with other containers. For example:
-  //
-  //     sourceContainer="main"
-  //     sourcePath="/mnt/data"
-  //
-  // combined with an associated VolumeMount on another container, would
-  // be one way to allow the main container to share some of its files
-  // (which may be just baked into the image, or provided by another storage
-  // system) with some other extraContainer for the task.
-  string sourceContainer = 1;
-  // The path in the container to be shared.
-  // This path may contain existing data to share, or it can simply
-  // not exist, and it will be created.
-  string sourcePath = 2;
 }
 
 // This data structure is associated with a service job and specifies the

--- a/src/main/proto/netflix/titus/titus_volumes.proto
+++ b/src/main/proto/netflix/titus/titus_volumes.proto
@@ -1,0 +1,85 @@
+
+syntax = "proto3";
+
+package com.netflix.titus;
+
+option java_multiple_files = true;
+option java_package = "com.netflix.titus.grpc.protogen";
+option java_outer_classname = "TitusVolumes";
+
+option go_package = "./netflix/titus";
+
+message SharedContainerVolumeSource {
+  // The sourceContainer is the name of the container with the
+  // path to be shared with other containers. For example:
+  //
+  //     sourceContainer="main"
+  //     sourcePath="/mnt/data"
+  //
+  // combined with an associated VolumeMount on another container, would
+  // be one way to allow the main container to share some of its files
+  // (which may be just baked into the image, or provided by another storage
+  // system) with some other extraContainer for the task.
+  string sourceContainer = 1;
+  // The path in the container to be shared.
+  // This path may contain existing data to share, or it can simply
+  // not exist, and it will be created.
+  string sourcePath = 2;
+}
+
+// Volumes define some sort of storage for a Task (pod) that is later referenced
+// by individual containers via VolumeMount declarations.
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core
+// Note that Titus only supports a subset of storage drivers.
+message Volume {
+  // (Required) the name of the volume. This is what is referenced by
+  // VolumeMount requests for individual containers.
+  string name = 1;
+
+  oneof VolumeSource {
+    // (Optional) A SharedContainerVolumeSource is a volume that exists on the
+    // one container that is exported. Such a volume can be used later via a
+    // VolumeMount and shared with other containers in the task (pod)
+    SharedContainerVolumeSource sharedContainerVolumeSource = 2;
+  }
+}
+
+// VolumeMounts are used to define how to mount a Volume in a container
+// Modeled after k8s volumeMounts:
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
+message VolumeMount {
+  // (Required) mountPath is the location inside the container where the volume
+  // will be mounted
+  string mountPath = 1;
+
+  enum MountPropagation {
+    // MountPropagationNone is the default and means that additional mounts
+    // inside a volumeMount will *not* be propagated.
+    MountPropagationNone = 0;
+
+    // MountPropagationHostToContainer specifies that mounts get propagated
+    // from the source mount to the destination ("rslave" in Linux).
+    MountPropagationHostToContainer = 1;
+
+    // MountPropagationBidirectional specifies that mounts get propagated from
+    // the and from the source container to the destination
+    // ("rshared" in Linux).
+    MountPropagationBidirectional = 2;
+  }
+
+  // mountPropagation determines how mounts are propagated from the host to
+  // container and the other way around. When not set, MountPropagationNone is
+  // used.
+  MountPropagation mountPropagation = 2;
+
+  // This must match the Name of a Volume.
+  string volumeName = 3;
+
+  // Mounted read-only if true, read-write otherwise (false or unspecified).
+  // Defaults to false.
+  bool readOnly = 4;
+
+  // Path within the volume from which the container's volume should be mounted.
+  // Defaults to "" (volume's root).
+  string subPath = 5;
+}


### PR DESCRIPTION
This extracts things like:

* volumes/VolumeMounts
* platformSidecars
* BasicContainer (used in extraContainers), and Image

Into titus_base so that they can be re-used in related Titus
products like CMB.

I'm up for suggestions on if you would like them to be in a
*different* file (titus_common?) but its kinda the same.

The important thing is that they are not specific to the *job* api.
