### PR TITLE
Breaking change: FCG API refactor

### DIFF
--- a/src/main/proto/netflix/titus/titus_federation_capacity_api.proto
+++ b/src/main/proto/netflix/titus/titus_federation_capacity_api.proto
@@ -16,19 +16,24 @@ message FederatedCapacityGroup {
   // Name of the federated CapacityGroup resource. This is used to uniquely identify existing resources.
   string capacityGroupName = 1;
 
-  // Total number of instances of the referenced ResourceDimension expected to use Compute capacity at the same time.
-  int32 instanceCount = 2;
-
-  // Expected resource requirement for each instance referencing the capacity group.
-  ResourceDimension resourceDimension = 3;
+  // This information contains the shape of a resource and a count of such resources reflective of the capacity
+  FederatedCapacity federatedCapacity = 2;
 
   // Resource pool to associate with the described capacity requirement. Each resource pool corresponds to
   // a varying degree of guaranteed availability of the Compute capacity.
-  string resourcePool = 4;
+  string resourcePool = 3;
 
   // A map containing Titus deployment cell name key and desired percent distribution value.
   // Sum of all distribution values should equal to 100%.
-  map<string, uint32> cellPercentDist = 5;
+  map<string, uint32> cellPercentDist = 4;
+};
+
+message FederatedCapacity {
+  // Total number of instances of the referenced ResourceDimension expected to use Compute capacity at the same time.
+  int32 instanceCount = 1;
+
+  // Expected resource requirement for each instance referencing the capacity group.
+  ResourceDimension resourceDimension = 2;
 };
 
 message CreateFederatedCapacityGroupRequest {
@@ -39,13 +44,15 @@ message CreateFederatedCapacityGroupRequest {
 message CreateFederatedCapacityGroupResponse {
 };
 
+message UpdateFederatedCapacityRequest {
+  // Name of the FederatedCapacityGroup to perform the update for
+  string capacityGroupName = 1;
 
-message UpdateFederatedCapacityGroupRequest {
-  // Existing FederatedCapacityGroup resource to update
-  FederatedCapacityGroup federatedCapacityGroup = 1;
+  // New value for the FederatedCapacity to update
+  FederatedCapacity federatedCapacity = 2;
 };
 
-message UpdateFederatedCapacityGroupResponse {
+message UpdateFederatedCapacityResponse {
 };
 
 message DeleteFederatedCapacityGroupRequest {
@@ -68,8 +75,8 @@ service FederatedCapacityGroupService {
   // Creates a FederatedCapacityGroup resource
   rpc CreateFederatedCapacityGroup(CreateFederatedCapacityGroupRequest) returns (CreateFederatedCapacityGroupResponse) {}
 
-  // Updates an existing FederatedCapacityGroup resource
-  rpc UpdateFederatedCapacityGroup(UpdateFederatedCapacityGroupRequest) returns (UpdateFederatedCapacityGroupResponse) {}
+  // Updates capacity on an existing FederatedCapacityGroup resource
+  rpc UpdateFederatedCapacity(UpdateFederatedCapacityRequest) returns (UpdateFederatedCapacityResponse) {}
 
   // Deletes an existing FederatedCapacityGroup resource
   rpc DeleteFederatedCapacityGroup(DeleteFederatedCapacityGroupRequest) returns (DeleteFederatedCapacityGroupResponse) {}


### PR DESCRIPTION
### Description of the Change
This is a backward incompatible change to specifically prevent direct updates to FCG cell distribution by end users.
- Refactor FederatedCapacityGroup message 
- Removed Update rpc for FCG
- Added Update rpc for subsection of FCG called FederatedCapacity