### PR TITLE
Updating step scaling policy alarm configuration

### DIFF
--- a/src/main/proto/netflix/titus/titus_autoscale_api.proto
+++ b/src/main/proto/netflix/titus/titus_autoscale_api.proto
@@ -54,6 +54,8 @@ message AlarmConfiguration {
   // The statistic for the metric associated with the alarm, other than
   // percentile.
   oneof statisticOneof { Statistic statistic = 8; }
+
+  repeated MetricDimension metricDimensions = 9;
 }
 
 // Describes step adjustment options

--- a/src/main/proto/netflix/titus/titus_autoscale_api.proto
+++ b/src/main/proto/netflix/titus/titus_autoscale_api.proto
@@ -54,7 +54,7 @@ message AlarmConfiguration {
   // The statistic for the metric associated with the alarm, other than
   // percentile.
   oneof statisticOneof { Statistic statistic = 8; }
-
+  // The dimensions for the metric specified in MetricName.
   repeated MetricDimension metricDimensions = 9;
 }
 


### PR DESCRIPTION
Step scaling policy configuration needs to support custom metric dimensions in order to build scaling on metrics that are not tagged with AutoScalingGroup (default)