### PR TITLE
Added new HighScalability network mode

### DIFF
--- a/doc/titus-agent-api-spec.html
+++ b/doc/titus-agent-api-spec.html
@@ -424,7 +424,7 @@ trust chain. </p></td>
                   <td>containerPorts</td>
                   <td><a href="#string">string</a></td>
                   <td>optional</td>
-                  <td><p> </p></td>
+                  <td><p><strong>Deprecated.</strong>  </p></td>
                 </tr>
               
                 <tr>
@@ -438,7 +438,7 @@ trust chain. </p></td>
                   <td>environmentVariable</td>
                   <td><a href="#messages.ContainerInfo.EnvironmentVariable">ContainerInfo.EnvironmentVariable</a></td>
                   <td>repeated</td>
-                  <td><p>deprecated: use userProvidedEnv and titusProvidedEnv instead </p></td>
+                  <td><p><strong>Deprecated.</strong> deprecated: use userProvidedEnv and titusProvidedEnv instead </p></td>
                 </tr>
               
                 <tr>
@@ -459,35 +459,35 @@ trust chain. </p></td>
                   <td>maxHealthFailures</td>
                   <td><a href="#uint32">uint32</a></td>
                   <td>optional</td>
-                  <td><p> </p></td>
+                  <td><p><strong>Deprecated.</strong>  </p></td>
                 </tr>
               
                 <tr>
                   <td>healthCheckCmd</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p> </p></td>
+                  <td><p><strong>Deprecated.</strong>  </p></td>
                 </tr>
               
                 <tr>
                   <td>snapshotPolicy</td>
                   <td><a href="#messages.ContainerInfo.SnapshotPolicy">ContainerInfo.SnapshotPolicy</a></td>
                   <td>optional</td>
-                  <td><p> </p></td>
+                  <td><p><strong>Deprecated.</strong>  </p></td>
                 </tr>
               
                 <tr>
                   <td>entrypointCmd</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>deprecated: Use process instead </p></td>
+                  <td><p><strong>Deprecated.</strong> deprecated: Use process instead </p></td>
                 </tr>
               
                 <tr>
                   <td>entrypointStr</td>
                   <td><a href="#string">string</a></td>
                   <td>optional</td>
-                  <td><p>deprecated: Use process instead </p></td>
+                  <td><p><strong>Deprecated.</strong> deprecated: Use process instead </p></td>
                 </tr>
               
                 <tr>
@@ -921,7 +921,7 @@ passed from API to executor </p></td>
                   <td>eniLablel</td>
                   <td><a href="#string">string</a></td>
                   <td>required</td>
-                  <td><p>deprecated: use eniLabel instead </p></td>
+                  <td><p><strong>Deprecated.</strong> deprecated: use eniLabel instead </p></td>
                 </tr>
               
                 <tr>

--- a/doc/titus-agent-api-spec.md
+++ b/doc/titus-agent-api-spec.md
@@ -92,16 +92,16 @@ strings
 | ----- | ---- | ----- | ----------- |
 | imageName | [string](#string) | optional |  |
 | command | [string](#string) | optional | deprecated. replaced by entrypointCmd. |
-| containerPorts | [string](#string) | optional |  |
+| containerPorts | [string](#string) | optional | **Deprecated.**  |
 | version | [string](#string) | optional |  Default: latest |
-| environmentVariable | [ContainerInfo.EnvironmentVariable](#messages.ContainerInfo.EnvironmentVariable) | repeated | deprecated: use userProvidedEnv and titusProvidedEnv instead |
+| environmentVariable | [ContainerInfo.EnvironmentVariable](#messages.ContainerInfo.EnvironmentVariable) | repeated | **Deprecated.** deprecated: use userProvidedEnv and titusProvidedEnv instead |
 | jobId | [string](#string) | optional |  |
 | logUploadRegexp | [string](#string) | optional |  |
-| maxHealthFailures | [uint32](#uint32) | optional |  |
-| healthCheckCmd | [string](#string) | repeated |  |
-| snapshotPolicy | [ContainerInfo.SnapshotPolicy](#messages.ContainerInfo.SnapshotPolicy) | optional |  |
-| entrypointCmd | [string](#string) | repeated | deprecated: Use process instead |
-| entrypointStr | [string](#string) | optional | deprecated: Use process instead |
+| maxHealthFailures | [uint32](#uint32) | optional | **Deprecated.**  |
+| healthCheckCmd | [string](#string) | repeated | **Deprecated.**  |
+| snapshotPolicy | [ContainerInfo.SnapshotPolicy](#messages.ContainerInfo.SnapshotPolicy) | optional | **Deprecated.**  |
+| entrypointCmd | [string](#string) | repeated | **Deprecated.** deprecated: Use process instead |
+| entrypointStr | [string](#string) | optional | **Deprecated.** deprecated: Use process instead |
 | appName | [string](#string) | optional |  |
 | jobGroupStack | [string](#string) | optional |  |
 | jobGroupDetail | [string](#string) | optional |  |
@@ -215,7 +215,7 @@ deprecated: use userProvidedEnv and titusProvidedEnv instead
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| eniLablel | [string](#string) | required | deprecated: use eniLabel instead |
+| eniLablel | [string](#string) | required | **Deprecated.** deprecated: use eniLabel instead |
 | eniLabel | [string](#string) | optional | this should be required, but it was added later (typo fix) and is optional for backwards compatibility |
 | securityGroups | [string](#string) | repeated |  |
 | bandwidthLimitMbps | [uint32](#uint32) | optional | In Mbps |

--- a/doc/titus-v3-spec.html
+++ b/doc/titus-v3-spec.html
@@ -1352,7 +1352,8 @@ from the same ordered number generator. </p></td>
                   <td>archived</td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
-                  <td><p>For internal usage only. Set to true if a job is finished and is moved to archive storage. </p></td>
+                  <td><p>For internal usage only. Set to true if a job is finished and is moved to
+archive storage. </p></td>
                 </tr>
               
             </tbody>
@@ -1400,7 +1401,8 @@ after a task is moved between jobs.
                   <td>archived</td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
-                  <td><p>For internal usage only. Set to true if a task is finished and is moved to archive storage. </p></td>
+                  <td><p>For internal usage only. Set to true if a task is finished and is moved
+to archive storage. </p></td>
                 </tr>
               
             </tbody>
@@ -2536,14 +2538,16 @@ only jobs with tasks that require migration </p></td>
                   <td>jobFields</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>(Optional) If set, only job field values explicitly given in this parameter will be returned </p></td>
+                  <td><p>(Optional) If set, only job field values explicitly given in this parameter
+will be returned </p></td>
                 </tr>
               
                 <tr>
                   <td>taskFields</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>(Optional) If set, only task field values explicitly given in this parameter will be returned </p></td>
+                  <td><p>(Optional) If set, only task field values explicitly given in this
+parameter will be returned </p></td>
                 </tr>
               
             </tbody>
@@ -3533,6 +3537,16 @@ allocated to the task.</p></td>
                 <td><p>IPv6 Only is for true believers, no IPv4 connectivity is provided.</p></td>
               </tr>
             
+              <tr>
+                <td>HighScale</td>
+                <td>5</td>
+                <td><p>HighScale is a special mode, which applies opinionated network settings
+to the workload for maximum scalability for the network.
+Enabling this mode *removes* the option for the user to select which
+subnets or security groups in use by the workload.
+Instead, special HighScale subnets and security groups are chosen.</p></td>
+              </tr>
+            
           </tbody>
         </table>
       
@@ -3717,8 +3731,9 @@ completes.</p></td>
                 <td>ObserveJobsWithKeepAlive</td>
                 <td><a href="#com.netflix.titus.ObserveJobsWithKeepAliveRequest">ObserveJobsWithKeepAliveRequest</a> stream</td>
                 <td><a href="#com.netflix.titus.JobChangeNotification">JobChangeNotification</a> stream</td>
-                <td><p>`ObserveJobsWithKeepAlive` extends the `ObserveJobs` endpoint behavior by supporting keep alive mechanism
-in the channel. This stream never completes.</p></td>
+                <td><p>`ObserveJobsWithKeepAlive` extends the `ObserveJobs` endpoint behavior by
+supporting keep alive mechanism in the channel. This stream never
+completes.</p></td>
               </tr>
             
               <tr>

--- a/doc/titus-v3-spec.md
+++ b/doc/titus-v3-spec.md
@@ -1450,6 +1450,7 @@ State information associated with a job.
 | Ipv6AndIpv4 | 2 | IPv6 And IPv4 (True Dual Stack), each task gets a unique v6 and v4 address. |
 | Ipv6AndIpv4Fallback | 3 | IPv6 and IPv4 Fallback uses the Titus IPv4 &#34;transition mechanism&#34; to give v4 connectivity transparently without providing every container their own IPv4 address. From a spinnaker/task perspective, only an IPv6 address is allocated to the task. |
 | Ipv6Only | 4 | IPv6 Only is for true believers, no IPv4 connectivity is provided. |
+| HighScale | 5 | HighScale is a special mode, which applies opinionated network settings to the workload for maximum scalability for the network. Enabling this mode *removes* the option for the user to select which subnets or security groups in use by the workload. Instead, special HighScale subnets and security groups are chosen. |
 
 
 

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -104,6 +104,12 @@ message NetworkConfiguration {
     Ipv6AndIpv4Fallback = 3;
     // IPv6 Only is for true believers, no IPv4 connectivity is provided.
     Ipv6Only = 4;
+    // HighScale is a special mode, which applies opinionated network settings
+    // to the workload for maximum scalability for the network.
+    // Enabling this mode *removes* the option for the user to select which
+    // subnets or security groups in use by the workload.
+    // Instead, special HighScale subnets and security groups are chosen.
+    HighScale = 5;
   }
   // Sets the overall network mode for all containers for a Task launched by
   // this job


### PR DESCRIPTION
This change adds a new networking mode to the list of available modes
for our API.

The new mode is an *opinionated* way of configuring networking, which
*removes* options like subnets and security groups (maybe more in the
future).

One might think that this could be done via the spinnaker UI, but that
would make it harder for our direct-api users (non-spinnaker) to use
this. The theory here is that we (titus) want to be able to change the
semantics for what this mode implies for *all* workloads that request
it, not just ones launched via spinnaker.