### PR TITLE
Added Image data to ContainerState

### DIFF
--- a/doc/titus-v3-spec.html
+++ b/doc/titus-v3-spec.html
@@ -3452,6 +3452,13 @@ state. Each job manager can introduce its own
                   <td><p>Enum representing if the individual container is healthy </p></td>
                 </tr>
               
+                <tr>
+                  <td>containerImage</td>
+                  <td><a href="#com.netflix.titus.BasicImage">BasicImage</a></td>
+                  <td></td>
+                  <td><p>Struct containing image information about the container </p></td>
+                </tr>
+              
             </tbody>
           </table>
 

--- a/doc/titus-v3-spec.md
+++ b/doc/titus-v3-spec.md
@@ -1417,6 +1417,7 @@ Finished jobs/tasks are not evaluated when the query is executed.
 | ----- | ---- | ----- | ----------- |
 | containerName | [string](#string) |  | Name of the container |
 | containerHealth | [TaskStatus.ContainerState.ContainerHealth](#com.netflix.titus.TaskStatus.ContainerState.ContainerHealth) |  | Enum representing if the individual container is healthy |
+| containerImage | [BasicImage](#com.netflix.titus.BasicImage) |  | Struct containing image information about the container |
 
 
 

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -631,6 +631,9 @@ message TaskStatus {
 
     // Enum representing if the individual container is healthy
     ContainerHealth containerHealth = 2;
+
+    // Struct containing image information about the container
+    BasicImage containerImage = 3;
   }
 
   // An array of ContainerStates, reporting the health of individual containers


### PR DESCRIPTION
Now that we have ContainerState working end-to-end, and actually visible
in the titus UI (and soon spinnaker UI), I would like to add Image data.

Just knowing the name of the container is a good start (it helps power
easy ssh links), but it would be also nice to know exactly what image
was used.

This this may be easy to see if you cross referenced it with a job, but
for platform-sidecars, the decision of exactly which version to use is
left to the runtime (webhook).

This PR allows us to get that data back out to the user in a structured
way.