### PR TITLE
Added platformSidecar to the container status message

### DIFF
--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -634,6 +634,9 @@ message TaskStatus {
 
     // Struct containing image information about the container
     BasicImage containerImage = 3;
+
+    // String representing the Platform Sidecar (if any) that added the container.
+    string platformSidecar = 4;
   }
 
   // An array of ContainerStates, reporting the health of individual containers


### PR DESCRIPTION
When we get the container statuses, we can't be 100% sure about which
containers have been added by which platform sidecar. Sure we could
inspect the job and "subtract" the user-containers, but still we
wouldn't be sure which platform sidecar injected which.

This information *is* encoded in the lowest levels of the pod via
annotations, but I don't want to make spinnnaker and other tools have to
do the calculation.

This new change adds room to the proto for the titus API to simply just
say which platform sidecar added the container (because the API can see
the pod, and can do the logic).
