### PR TITLE
fix go_package to be consistent and work with latest protoc-gen-go

### DIFF
--- a/src/main/proto/netflix/titus/titus_agent_api.proto
+++ b/src/main/proto/netflix/titus/titus_agent_api.proto
@@ -12,7 +12,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "AgentProto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 // ----------------------------------------------------------------------------
 // Agent cluster management data structures

--- a/src/main/proto/netflix/titus/titus_autoscale_api.proto
+++ b/src/main/proto/netflix/titus/titus_autoscale_api.proto
@@ -12,7 +12,7 @@ import "google/protobuf/wrappers.proto";
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 // Describes an alarm configuration.
 //  Note that this is currently only use for step scaling.

--- a/src/main/proto/netflix/titus/titus_cluster_membership_api.proto
+++ b/src/main/proto/netflix/titus/titus_cluster_membership_api.proto
@@ -17,7 +17,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "ClusterMembershipProto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 // ----------------------------------------------------------------------------
 // Titus supervisor data model.

--- a/src/main/proto/netflix/titus/titus_eviction_api.proto
+++ b/src/main/proto/netflix/titus/titus_eviction_api.proto
@@ -14,7 +14,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "EvictionProto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 // ----------------------------------------------------------------------------
 // Eviction core data structures

--- a/src/main/proto/netflix/titus/titus_health.proto
+++ b/src/main/proto/netflix/titus/titus_health.proto
@@ -12,7 +12,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "HealthProto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 message HealthCheckRequest {
   // reserved for future use as per the GRPC Health Checking protocol, but

--- a/src/main/proto/netflix/titus/titus_job_api_ext.proto
+++ b/src/main/proto/netflix/titus/titus_job_api_ext.proto
@@ -13,7 +13,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "JobProtoExt";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 message ContainerExt {
 

--- a/src/main/proto/netflix/titus/titus_loadbalancer_api.proto
+++ b/src/main/proto/netflix/titus/titus_loadbalancer_api.proto
@@ -12,6 +12,8 @@ import "netflix/titus/titus_base.proto";
 option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 
+option go_package = "./netflix/titus";
+
 // Message that identifies a single load balancer association.
 // For ALB integration this ID will be the AWS ARN of the IP Target Group,
 // not a load balancer specifically.

--- a/src/main/proto/netflix/titus/titus_master_api.proto
+++ b/src/main/proto/netflix/titus/titus_master_api.proto
@@ -16,7 +16,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "TitusMasterProto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 // ----------------------------------------------------------------------------
 // Titus supervisor data model.

--- a/src/main/proto/netflix/titus/titus_scheduler_api.proto
+++ b/src/main/proto/netflix/titus/titus_scheduler_api.proto
@@ -10,7 +10,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "SchedulerProto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 // ----------------------------------------------------------------------------
 // Scheduler data structures

--- a/src/main/proto/netflix/titus/titus_task_relocation_api.proto
+++ b/src/main/proto/netflix/titus/titus_task_relocation_api.proto
@@ -11,7 +11,7 @@ option java_multiple_files = true;
 option java_package = "com.netflix.titus.grpc.protogen";
 option java_outer_classname = "TaskRelocationProto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 // ----------------------------------------------------------------------------
 // Task relocation core data structures

--- a/src/main/proto/netflix/titus/titus_vpc_api.proto
+++ b/src/main/proto/netflix/titus/titus_vpc_api.proto
@@ -4,7 +4,7 @@ package com.netflix.titus;
 import "netflix/titus/titus_base.proto";
 import "google/protobuf/empty.proto";
 
-option go_package = "titus";
+option go_package = "./netflix/titus";
 
 enum Family {
   // Default should never really be used, but we're required to have one due to


### PR DESCRIPTION
go_package was not consistent across files. This makes it consistent and "correct" according to protoc-gen-go's requirement of having at least one "." or "/".

This also removes the need to do a bunch of `--go_opt=M...` junk.