### PR TITLE
RFC: Per-container capabilities

### DIFF
--- a/src/main/proto/netflix/titus/titus_containers.proto
+++ b/src/main/proto/netflix/titus/titus_containers.proto
@@ -45,6 +45,10 @@ message BasicContainer {
   // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
   // for more technical details.
   repeated VolumeMount volumeMounts = 6;
+
+  // (Optional) additional capabilities for the container to have to enable
+  // certain advanced features
+  ContainerCapabilities containerCapabilities = 12;
 }
 
 // To reference an image, a user has to provide an image name and a version. A
@@ -80,4 +84,17 @@ message PlatformSidecar {
 
   // (Optional) Arguments, KV pairs for configuring the sidecar
   google.protobuf.Struct arguments = 3;
+}
+
+enum ContainerCapabilities {
+  // ContainerCapabiltilesDefault is the default capability set
+  ContainerCapabiltilesDefault = 0;
+
+  // ContainerCapabiltilesFUSE gives a container the capability to mount
+  // FUSE mounts (usually into /mnt-shared/)
+  ContainerCapabiltilesFUSE = 1;
+
+  // ContainerCapabiltilesImageBuilding sets up a container for the ability to build
+  // container images *inside* the container itself
+  ContainerCapabiltilesImageBuilding = 2;
 }

--- a/src/main/proto/netflix/titus/titus_job_api.proto
+++ b/src/main/proto/netflix/titus/titus_job_api.proto
@@ -243,6 +243,10 @@ message Container {
   // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volumemount-v1-core
   // for more technical details.
   repeated VolumeMount volumeMounts = 11;
+
+  // (Optional) additional capabilities for the container to have to enable
+  // certain advanced features
+  ContainerCapabilities containerCapabilities = 12;
 }
 
 // This data structure is associated with a service job and specifies the


### PR DESCRIPTION
For a long time, we "hid" capabilities in container attributes.
I think we are ready to promote this feature as a first class citizen in
the API, and extend it to be per-container (not for a whole pod like
attributes are)

Also, I would like an ENUM so that we can package up related security
features (seccomp, apparmor, CAPs) into a high-level package, and not
expose individiual security settings to a user. (so you can't forget to
set the right fuse/seccomp/cap settings all correctly to enable fuse.
